### PR TITLE
include hidapi sources in tree

### DIFF
--- a/LICENSE-hidapi.txt
+++ b/LICENSE-hidapi.txt
@@ -1,0 +1,9 @@
+ HIDAPI - Multi-Platform library for
+ communication with HID devices.
+
+ Copyright 2009, Alan Ott, Signal 11 Software.
+ All Rights Reserved.
+ 
+ This software may be used by anyone for any reason so
+ long as the copyright notice in the source files
+ remains intact.

--- a/hid.go
+++ b/hid.go
@@ -12,8 +12,7 @@ package hid
 #cgo linux LDFLAGS: -lusb-1.0
 #cgo darwin LDFLAGS: -framework IOKit -framework CoreFoundation
 #cgo windows LDFLAGS: -lsetupapi
-#cgo LDFLAGS: -lhidapi
-#include <hidapi/hidapi.h>
+#include "hidapi.h"
 #include <stdlib.h>
 */
 import "C"

--- a/hid_darwin.c
+++ b/hid_darwin.c
@@ -1,0 +1,1112 @@
+/*******************************************************
+ HIDAPI - Multi-Platform library for
+ communication with HID devices.
+
+ Alan Ott
+ Signal 11 Software
+
+ 2010-07-03
+
+ Copyright 2010, All Rights Reserved.
+
+ At the discretion of the user of this library,
+ this software may be licensed under the terms of the
+ GNU General Public License v3, a BSD-Style license, or the
+ original HIDAPI license as outlined in the LICENSE.txt,
+ LICENSE-gpl3.txt, LICENSE-bsd.txt, and LICENSE-orig.txt
+ files located at the root of the source distribution.
+ These files may also be found in the public source
+ code repository located at:
+        http://github.com/signal11/hidapi .
+********************************************************/
+
+/* See Apple Technical Note TN2187 for details on IOHidManager. */
+
+#include <IOKit/hid/IOHIDManager.h>
+#include <IOKit/hid/IOHIDKeys.h>
+#include <CoreFoundation/CoreFoundation.h>
+#include <wchar.h>
+#include <locale.h>
+#include <pthread.h>
+#include <sys/time.h>
+#include <unistd.h>
+
+#include "hidapi.h"
+
+/* Barrier implementation because Mac OSX doesn't have pthread_barrier.
+   It also doesn't have clock_gettime(). So much for POSIX and SUSv2.
+   This implementation came from Brent Priddy and was posted on
+   StackOverflow. It is used with his permission. */
+typedef int pthread_barrierattr_t;
+typedef struct pthread_barrier {
+    pthread_mutex_t mutex;
+    pthread_cond_t cond;
+    int count;
+    int trip_count;
+} pthread_barrier_t;
+
+static int pthread_barrier_init(pthread_barrier_t *barrier, const pthread_barrierattr_t *attr, unsigned int count)
+{
+	if(count == 0) {
+		errno = EINVAL;
+		return -1;
+	}
+
+	if(pthread_mutex_init(&barrier->mutex, 0) < 0) {
+		return -1;
+	}
+	if(pthread_cond_init(&barrier->cond, 0) < 0) {
+		pthread_mutex_destroy(&barrier->mutex);
+		return -1;
+	}
+	barrier->trip_count = count;
+	barrier->count = 0;
+
+	return 0;
+}
+
+static int pthread_barrier_destroy(pthread_barrier_t *barrier)
+{
+	pthread_cond_destroy(&barrier->cond);
+	pthread_mutex_destroy(&barrier->mutex);
+	return 0;
+}
+
+static int pthread_barrier_wait(pthread_barrier_t *barrier)
+{
+	pthread_mutex_lock(&barrier->mutex);
+	++(barrier->count);
+	if(barrier->count >= barrier->trip_count)
+	{
+		barrier->count = 0;
+		pthread_cond_broadcast(&barrier->cond);
+		pthread_mutex_unlock(&barrier->mutex);
+		return 1;
+	}
+	else
+	{
+		pthread_cond_wait(&barrier->cond, &(barrier->mutex));
+		pthread_mutex_unlock(&barrier->mutex);
+		return 0;
+	}
+}
+
+static int return_data(hid_device *dev, unsigned char *data, size_t length);
+
+/* Linked List of input reports received from the device. */
+struct input_report {
+	uint8_t *data;
+	size_t len;
+	struct input_report *next;
+};
+
+struct hid_device_ {
+	IOHIDDeviceRef device_handle;
+	int blocking;
+	int uses_numbered_reports;
+	int disconnected;
+	CFStringRef run_loop_mode;
+	CFRunLoopRef run_loop;
+	CFRunLoopSourceRef source;
+	uint8_t *input_report_buf;
+	CFIndex max_input_report_len;
+	struct input_report *input_reports;
+
+	pthread_t thread;
+	pthread_mutex_t mutex; /* Protects input_reports */
+	pthread_cond_t condition;
+	pthread_barrier_t barrier; /* Ensures correct startup sequence */
+	pthread_barrier_t shutdown_barrier; /* Ensures correct shutdown sequence */
+	int shutdown_thread;
+};
+
+static hid_device *new_hid_device(void)
+{
+	hid_device *dev = calloc(1, sizeof(hid_device));
+	dev->device_handle = NULL;
+	dev->blocking = 1;
+	dev->uses_numbered_reports = 0;
+	dev->disconnected = 0;
+	dev->run_loop_mode = NULL;
+	dev->run_loop = NULL;
+	dev->source = NULL;
+	dev->input_report_buf = NULL;
+	dev->input_reports = NULL;
+	dev->shutdown_thread = 0;
+
+	/* Thread objects */
+	pthread_mutex_init(&dev->mutex, NULL);
+	pthread_cond_init(&dev->condition, NULL);
+	pthread_barrier_init(&dev->barrier, NULL, 2);
+	pthread_barrier_init(&dev->shutdown_barrier, NULL, 2);
+
+	return dev;
+}
+
+static void free_hid_device(hid_device *dev)
+{
+	if (!dev)
+		return;
+
+	/* Delete any input reports still left over. */
+	struct input_report *rpt = dev->input_reports;
+	while (rpt) {
+		struct input_report *next = rpt->next;
+		free(rpt->data);
+		free(rpt);
+		rpt = next;
+	}
+
+	/* Free the string and the report buffer. The check for NULL
+	   is necessary here as CFRelease() doesn't handle NULL like
+	   free() and others do. */
+	if (dev->run_loop_mode)
+		CFRelease(dev->run_loop_mode);
+	if (dev->source)
+		CFRelease(dev->source);
+	free(dev->input_report_buf);
+
+	/* Clean up the thread objects */
+	pthread_barrier_destroy(&dev->shutdown_barrier);
+	pthread_barrier_destroy(&dev->barrier);
+	pthread_cond_destroy(&dev->condition);
+	pthread_mutex_destroy(&dev->mutex);
+
+	/* Free the structure itself. */
+	free(dev);
+}
+
+static	IOHIDManagerRef hid_mgr = 0x0;
+
+
+#if 0
+static void register_error(hid_device *device, const char *op)
+{
+
+}
+#endif
+
+
+static int32_t get_int_property(IOHIDDeviceRef device, CFStringRef key)
+{
+	CFTypeRef ref;
+	int32_t value;
+
+	ref = IOHIDDeviceGetProperty(device, key);
+	if (ref) {
+		if (CFGetTypeID(ref) == CFNumberGetTypeID()) {
+			CFNumberGetValue((CFNumberRef) ref, kCFNumberSInt32Type, &value);
+			return value;
+		}
+	}
+	return 0;
+}
+
+static unsigned short get_vendor_id(IOHIDDeviceRef device)
+{
+	return get_int_property(device, CFSTR(kIOHIDVendorIDKey));
+}
+
+static unsigned short get_product_id(IOHIDDeviceRef device)
+{
+	return get_int_property(device, CFSTR(kIOHIDProductIDKey));
+}
+
+static int32_t get_location_id(IOHIDDeviceRef device)
+{
+	return get_int_property(device, CFSTR(kIOHIDLocationIDKey));
+}
+
+static int32_t get_max_report_length(IOHIDDeviceRef device)
+{
+	return get_int_property(device, CFSTR(kIOHIDMaxInputReportSizeKey));
+}
+
+static int get_string_property(IOHIDDeviceRef device, CFStringRef prop, wchar_t *buf, size_t len)
+{
+	CFStringRef str;
+
+	if (!len)
+		return 0;
+
+	str = IOHIDDeviceGetProperty(device, prop);
+
+	buf[0] = 0;
+
+	if (str) {
+		CFIndex str_len = CFStringGetLength(str);
+		CFRange range;
+		CFIndex used_buf_len;
+		CFIndex chars_copied;
+
+		len --;
+
+		range.location = 0;
+		range.length = ((size_t)str_len > len)? len: (size_t)str_len;
+		chars_copied = CFStringGetBytes(str,
+			range,
+			kCFStringEncodingUTF32LE,
+			(char)'?',
+			FALSE,
+			(UInt8*)buf,
+			len * sizeof(wchar_t),
+			&used_buf_len);
+
+		if (chars_copied == len)
+			buf[len] = 0; /* len is decremented above */
+		else
+			buf[chars_copied] = 0;
+
+		return 0;
+	}
+	else
+		return -1;
+
+}
+
+static int get_string_property_utf8(IOHIDDeviceRef device, CFStringRef prop, char *buf, size_t len)
+{
+	CFStringRef str;
+	if (!len)
+		return 0;
+
+	str = IOHIDDeviceGetProperty(device, prop);
+
+	buf[0] = 0;
+
+	if (str) {
+		len--;
+
+		CFIndex str_len = CFStringGetLength(str);
+		CFRange range;
+		range.location = 0;
+		range.length = str_len;
+		CFIndex used_buf_len;
+		CFIndex chars_copied;
+		chars_copied = CFStringGetBytes(str,
+			range,
+			kCFStringEncodingUTF8,
+			(char)'?',
+			FALSE,
+			(UInt8*)buf,
+			len,
+			&used_buf_len);
+
+		if (used_buf_len == len)
+			buf[len] = 0; /* len is decremented above */
+		else
+			buf[used_buf_len] = 0;
+
+		return used_buf_len;
+	}
+	else
+		return 0;
+}
+
+
+static int get_serial_number(IOHIDDeviceRef device, wchar_t *buf, size_t len)
+{
+	return get_string_property(device, CFSTR(kIOHIDSerialNumberKey), buf, len);
+}
+
+static int get_manufacturer_string(IOHIDDeviceRef device, wchar_t *buf, size_t len)
+{
+	return get_string_property(device, CFSTR(kIOHIDManufacturerKey), buf, len);
+}
+
+static int get_product_string(IOHIDDeviceRef device, wchar_t *buf, size_t len)
+{
+	return get_string_property(device, CFSTR(kIOHIDProductKey), buf, len);
+}
+
+
+/* Implementation of wcsdup() for Mac. */
+static wchar_t *dup_wcs(const wchar_t *s)
+{
+	size_t len = wcslen(s);
+	wchar_t *ret = malloc((len+1)*sizeof(wchar_t));
+	wcscpy(ret, s);
+
+	return ret;
+}
+
+
+static int make_path(IOHIDDeviceRef device, char *buf, size_t len)
+{
+	int res;
+	unsigned short vid, pid;
+	char transport[32];
+	int32_t location;
+
+	buf[0] = '\0';
+
+	res = get_string_property_utf8(
+		device, CFSTR(kIOHIDTransportKey),
+		transport, sizeof(transport));
+
+	if (!res)
+		return -1;
+
+	location = get_location_id(device);
+	vid = get_vendor_id(device);
+	pid = get_product_id(device);
+
+	res = snprintf(buf, len, "%s_%04hx_%04hx_%x",
+                       transport, vid, pid, location);
+
+
+	buf[len-1] = '\0';
+	return res+1;
+}
+
+/* Initialize the IOHIDManager. Return 0 for success and -1 for failure. */
+static int init_hid_manager(void)
+{
+	/* Initialize all the HID Manager Objects */
+	hid_mgr = IOHIDManagerCreate(kCFAllocatorDefault, kIOHIDOptionsTypeNone);
+	if (hid_mgr) {
+		IOHIDManagerSetDeviceMatching(hid_mgr, NULL);
+		IOHIDManagerScheduleWithRunLoop(hid_mgr, CFRunLoopGetCurrent(), kCFRunLoopDefaultMode);
+		return 0;
+	}
+
+	return -1;
+}
+
+/* Initialize the IOHIDManager if necessary. This is the public function, and
+   it is safe to call this function repeatedly. Return 0 for success and -1
+   for failure. */
+int HID_API_EXPORT hid_init(void)
+{
+	if (!hid_mgr) {
+		return init_hid_manager();
+	}
+
+	/* Already initialized. */
+	return 0;
+}
+
+int HID_API_EXPORT hid_exit(void)
+{
+	if (hid_mgr) {
+		/* Close the HID manager. */
+		IOHIDManagerClose(hid_mgr, kIOHIDOptionsTypeNone);
+		CFRelease(hid_mgr);
+		hid_mgr = NULL;
+	}
+
+	return 0;
+}
+
+static void process_pending_events(void) {
+	SInt32 res;
+	do {
+		res = CFRunLoopRunInMode(kCFRunLoopDefaultMode, 0.001, FALSE);
+	} while(res != kCFRunLoopRunFinished && res != kCFRunLoopRunTimedOut);
+}
+
+struct hid_device_info  HID_API_EXPORT *hid_enumerate(unsigned short vendor_id, unsigned short product_id)
+{
+	struct hid_device_info *root = NULL; /* return object */
+	struct hid_device_info *cur_dev = NULL;
+	CFIndex num_devices;
+	int i;
+
+	/* Set up the HID Manager if it hasn't been done */
+	if (hid_init() < 0)
+		return NULL;
+
+	/* give the IOHIDManager a chance to update itself */
+	process_pending_events();
+
+	/* Get a list of the Devices */
+	IOHIDManagerSetDeviceMatching(hid_mgr, NULL);
+	CFSetRef device_set = IOHIDManagerCopyDevices(hid_mgr);
+
+	/* Convert the list into a C array so we can iterate easily. */
+	num_devices = CFSetGetCount(device_set);
+	IOHIDDeviceRef *device_array = calloc(num_devices, sizeof(IOHIDDeviceRef));
+	CFSetGetValues(device_set, (const void **) device_array);
+
+	/* Iterate over each device, making an entry for it. */
+	for (i = 0; i < num_devices; i++) {
+		unsigned short dev_vid;
+		unsigned short dev_pid;
+		#define BUF_LEN 256
+		wchar_t buf[BUF_LEN];
+		char cbuf[BUF_LEN];
+
+		IOHIDDeviceRef dev = device_array[i];
+
+        if (!dev) {
+            continue;
+        }
+		dev_vid = get_vendor_id(dev);
+		dev_pid = get_product_id(dev);
+
+		/* Check the VID/PID against the arguments */
+		if ((vendor_id == 0x0 || vendor_id == dev_vid) &&
+		    (product_id == 0x0 || product_id == dev_pid)) {
+			struct hid_device_info *tmp;
+			size_t len;
+
+			/* VID/PID match. Create the record. */
+			tmp = malloc(sizeof(struct hid_device_info));
+			if (cur_dev) {
+				cur_dev->next = tmp;
+			}
+			else {
+				root = tmp;
+			}
+			cur_dev = tmp;
+
+			/* Get the Usage Page and Usage for this device. */
+			cur_dev->usage_page = get_int_property(dev, CFSTR(kIOHIDPrimaryUsagePageKey));
+			cur_dev->usage = get_int_property(dev, CFSTR(kIOHIDPrimaryUsageKey));
+
+			/* Fill out the record */
+			cur_dev->next = NULL;
+			len = make_path(dev, cbuf, sizeof(cbuf));
+			cur_dev->path = strdup(cbuf);
+
+			/* Serial Number */
+			get_serial_number(dev, buf, BUF_LEN);
+			cur_dev->serial_number = dup_wcs(buf);
+
+			/* Manufacturer and Product strings */
+			get_manufacturer_string(dev, buf, BUF_LEN);
+			cur_dev->manufacturer_string = dup_wcs(buf);
+			get_product_string(dev, buf, BUF_LEN);
+			cur_dev->product_string = dup_wcs(buf);
+
+			/* VID/PID */
+			cur_dev->vendor_id = dev_vid;
+			cur_dev->product_id = dev_pid;
+
+			/* Release Number */
+			cur_dev->release_number = get_int_property(dev, CFSTR(kIOHIDVersionNumberKey));
+
+			/* Interface Number (Unsupported on Mac)*/
+			cur_dev->interface_number = -1;
+		}
+	}
+
+	free(device_array);
+	CFRelease(device_set);
+
+	return root;
+}
+
+void  HID_API_EXPORT hid_free_enumeration(struct hid_device_info *devs)
+{
+	/* This function is identical to the Linux version. Platform independent. */
+	struct hid_device_info *d = devs;
+	while (d) {
+		struct hid_device_info *next = d->next;
+		free(d->path);
+		free(d->serial_number);
+		free(d->manufacturer_string);
+		free(d->product_string);
+		free(d);
+		d = next;
+	}
+}
+
+hid_device * HID_API_EXPORT hid_open(unsigned short vendor_id, unsigned short product_id, const wchar_t *serial_number)
+{
+	/* This function is identical to the Linux version. Platform independent. */
+	struct hid_device_info *devs, *cur_dev;
+	const char *path_to_open = NULL;
+	hid_device * handle = NULL;
+
+	devs = hid_enumerate(vendor_id, product_id);
+	cur_dev = devs;
+	while (cur_dev) {
+		if (cur_dev->vendor_id == vendor_id &&
+		    cur_dev->product_id == product_id) {
+			if (serial_number) {
+				if (wcscmp(serial_number, cur_dev->serial_number) == 0) {
+					path_to_open = cur_dev->path;
+					break;
+				}
+			}
+			else {
+				path_to_open = cur_dev->path;
+				break;
+			}
+		}
+		cur_dev = cur_dev->next;
+	}
+
+	if (path_to_open) {
+		/* Open the device */
+		handle = hid_open_path(path_to_open);
+	}
+
+	hid_free_enumeration(devs);
+
+	return handle;
+}
+
+static void hid_device_removal_callback(void *context, IOReturn result,
+                                        void *sender)
+{
+	/* Stop the Run Loop for this device. */
+	hid_device *d = context;
+
+	d->disconnected = 1;
+	CFRunLoopStop(d->run_loop);
+}
+
+/* The Run Loop calls this function for each input report received.
+   This function puts the data into a linked list to be picked up by
+   hid_read(). */
+static void hid_report_callback(void *context, IOReturn result, void *sender,
+                         IOHIDReportType report_type, uint32_t report_id,
+                         uint8_t *report, CFIndex report_length)
+{
+	struct input_report *rpt;
+	hid_device *dev = context;
+
+	/* Make a new Input Report object */
+	rpt = calloc(1, sizeof(struct input_report));
+	rpt->data = calloc(1, report_length);
+	memcpy(rpt->data, report, report_length);
+	rpt->len = report_length;
+	rpt->next = NULL;
+
+	/* Lock this section */
+	pthread_mutex_lock(&dev->mutex);
+
+	/* Attach the new report object to the end of the list. */
+	if (dev->input_reports == NULL) {
+		/* The list is empty. Put it at the root. */
+		dev->input_reports = rpt;
+	}
+	else {
+		/* Find the end of the list and attach. */
+		struct input_report *cur = dev->input_reports;
+		int num_queued = 0;
+		while (cur->next != NULL) {
+			cur = cur->next;
+			num_queued++;
+		}
+		cur->next = rpt;
+
+		/* Pop one off if we've reached 30 in the queue. This
+		   way we don't grow forever if the user never reads
+		   anything from the device. */
+		if (num_queued > 30) {
+			return_data(dev, NULL, 0);
+		}
+	}
+
+	/* Signal a waiting thread that there is data. */
+	pthread_cond_signal(&dev->condition);
+
+	/* Unlock */
+	pthread_mutex_unlock(&dev->mutex);
+
+}
+
+/* This gets called when the read_thred's run loop gets signaled by
+   hid_close(), and serves to stop the read_thread's run loop. */
+static void perform_signal_callback(void *context)
+{
+	hid_device *dev = context;
+	CFRunLoopStop(dev->run_loop); /*TODO: CFRunLoopGetCurrent()*/
+}
+
+static void *read_thread(void *param)
+{
+	hid_device *dev = param;
+	SInt32 code;
+
+	/* Move the device's run loop to this thread. */
+	IOHIDDeviceScheduleWithRunLoop(dev->device_handle, CFRunLoopGetCurrent(), dev->run_loop_mode);
+
+	/* Create the RunLoopSource which is used to signal the
+	   event loop to stop when hid_close() is called. */
+	CFRunLoopSourceContext ctx;
+	memset(&ctx, 0, sizeof(ctx));
+	ctx.version = 0;
+	ctx.info = dev;
+	ctx.perform = &perform_signal_callback;
+	dev->source = CFRunLoopSourceCreate(kCFAllocatorDefault, 0/*order*/, &ctx);
+	CFRunLoopAddSource(CFRunLoopGetCurrent(), dev->source, dev->run_loop_mode);
+
+	/* Store off the Run Loop so it can be stopped from hid_close()
+	   and on device disconnection. */
+	dev->run_loop = CFRunLoopGetCurrent();
+
+	/* Notify the main thread that the read thread is up and running. */
+	pthread_barrier_wait(&dev->barrier);
+
+	/* Run the Event Loop. CFRunLoopRunInMode() will dispatch HID input
+	   reports into the hid_report_callback(). */
+	while (!dev->shutdown_thread && !dev->disconnected) {
+		code = CFRunLoopRunInMode(dev->run_loop_mode, 1000/*sec*/, FALSE);
+		/* Return if the device has been disconnected */
+		if (code == kCFRunLoopRunFinished) {
+			dev->disconnected = 1;
+			break;
+		}
+
+
+		/* Break if The Run Loop returns Finished or Stopped. */
+		if (code != kCFRunLoopRunTimedOut &&
+		    code != kCFRunLoopRunHandledSource) {
+			/* There was some kind of error. Setting
+			   shutdown seems to make sense, but
+			   there may be something else more appropriate */
+			dev->shutdown_thread = 1;
+			break;
+		}
+	}
+
+	/* Now that the read thread is stopping, Wake any threads which are
+	   waiting on data (in hid_read_timeout()). Do this under a mutex to
+	   make sure that a thread which is about to go to sleep waiting on
+	   the condition acutally will go to sleep before the condition is
+	   signaled. */
+	pthread_mutex_lock(&dev->mutex);
+	pthread_cond_broadcast(&dev->condition);
+	pthread_mutex_unlock(&dev->mutex);
+
+	/* Wait here until hid_close() is called and makes it past
+	   the call to CFRunLoopWakeUp(). This thread still needs to
+	   be valid when that function is called on the other thread. */
+	pthread_barrier_wait(&dev->shutdown_barrier);
+
+	return NULL;
+}
+
+hid_device * HID_API_EXPORT hid_open_path(const char *path)
+{
+	int i;
+	hid_device *dev = NULL;
+	CFIndex num_devices;
+
+	dev = new_hid_device();
+
+	/* Set up the HID Manager if it hasn't been done */
+	if (hid_init() < 0)
+		return NULL;
+
+	/* give the IOHIDManager a chance to update itself */
+	process_pending_events();
+
+	CFSetRef device_set = IOHIDManagerCopyDevices(hid_mgr);
+
+	num_devices = CFSetGetCount(device_set);
+	IOHIDDeviceRef *device_array = calloc(num_devices, sizeof(IOHIDDeviceRef));
+	CFSetGetValues(device_set, (const void **) device_array);
+	for (i = 0; i < num_devices; i++) {
+		char cbuf[BUF_LEN];
+		size_t len;
+		IOHIDDeviceRef os_dev = device_array[i];
+
+		len = make_path(os_dev, cbuf, sizeof(cbuf));
+		if (!strcmp(cbuf, path)) {
+			/* Matched Paths. Open this Device. */
+			IOReturn ret = IOHIDDeviceOpen(os_dev, kIOHIDOptionsTypeSeizeDevice);
+			if (ret == kIOReturnSuccess) {
+				char str[32];
+
+				free(device_array);
+				CFRetain(os_dev);
+				CFRelease(device_set);
+				dev->device_handle = os_dev;
+
+				/* Create the buffers for receiving data */
+				dev->max_input_report_len = (CFIndex) get_max_report_length(os_dev);
+				dev->input_report_buf = calloc(dev->max_input_report_len, sizeof(uint8_t));
+
+				/* Create the Run Loop Mode for this device.
+				   printing the reference seems to work. */
+				sprintf(str, "HIDAPI_%p", os_dev);
+				dev->run_loop_mode =
+					CFStringCreateWithCString(NULL, str, kCFStringEncodingASCII);
+
+				/* Attach the device to a Run Loop */
+				IOHIDDeviceRegisterInputReportCallback(
+					os_dev, dev->input_report_buf, dev->max_input_report_len,
+					&hid_report_callback, dev);
+				IOHIDDeviceRegisterRemovalCallback(dev->device_handle, hid_device_removal_callback, dev);
+
+				/* Start the read thread */
+				pthread_create(&dev->thread, NULL, read_thread, dev);
+
+				/* Wait here for the read thread to be initialized. */
+				pthread_barrier_wait(&dev->barrier);
+
+				return dev;
+			}
+			else {
+				goto return_error;
+			}
+		}
+	}
+
+return_error:
+	free(device_array);
+	CFRelease(device_set);
+	free_hid_device(dev);
+	return NULL;
+}
+
+static int set_report(hid_device *dev, IOHIDReportType type, const unsigned char *data, size_t length)
+{
+	const unsigned char *data_to_send;
+	size_t length_to_send;
+	IOReturn res;
+
+	/* Return if the device has been disconnected. */
+	if (dev->disconnected)
+		return -1;
+
+	if (data[0] == 0x0) {
+		/* Not using numbered Reports.
+		   Don't send the report number. */
+		data_to_send = data+1;
+		length_to_send = length-1;
+	}
+	else {
+		/* Using numbered Reports.
+		   Send the Report Number */
+		data_to_send = data;
+		length_to_send = length;
+	}
+
+	if (!dev->disconnected) {
+		res = IOHIDDeviceSetReport(dev->device_handle,
+					   type,
+					   data[0], /* Report ID*/
+					   data_to_send, length_to_send);
+
+		if (res == kIOReturnSuccess) {
+			return length;
+		}
+		else
+			return -1;
+	}
+
+	return -1;
+}
+
+int HID_API_EXPORT hid_write(hid_device *dev, const unsigned char *data, size_t length)
+{
+	return set_report(dev, kIOHIDReportTypeOutput, data, length);
+}
+
+/* Helper function, so that this isn't duplicated in hid_read(). */
+static int return_data(hid_device *dev, unsigned char *data, size_t length)
+{
+	/* Copy the data out of the linked list item (rpt) into the
+	   return buffer (data), and delete the liked list item. */
+	struct input_report *rpt = dev->input_reports;
+	size_t len = (length < rpt->len)? length: rpt->len;
+	memcpy(data, rpt->data, len);
+	dev->input_reports = rpt->next;
+	free(rpt->data);
+	free(rpt);
+	return len;
+}
+
+static int cond_wait(const hid_device *dev, pthread_cond_t *cond, pthread_mutex_t *mutex)
+{
+	while (!dev->input_reports) {
+		int res = pthread_cond_wait(cond, mutex);
+		if (res != 0)
+			return res;
+
+		/* A res of 0 means we may have been signaled or it may
+		   be a spurious wakeup. Check to see that there's acutally
+		   data in the queue before returning, and if not, go back
+		   to sleep. See the pthread_cond_timedwait() man page for
+		   details. */
+
+		if (dev->shutdown_thread || dev->disconnected)
+			return -1;
+	}
+
+	return 0;
+}
+
+static int cond_timedwait(const hid_device *dev, pthread_cond_t *cond, pthread_mutex_t *mutex, const struct timespec *abstime)
+{
+	while (!dev->input_reports) {
+		int res = pthread_cond_timedwait(cond, mutex, abstime);
+		if (res != 0)
+			return res;
+
+		/* A res of 0 means we may have been signaled or it may
+		   be a spurious wakeup. Check to see that there's acutally
+		   data in the queue before returning, and if not, go back
+		   to sleep. See the pthread_cond_timedwait() man page for
+		   details. */
+
+		if (dev->shutdown_thread || dev->disconnected)
+			return -1;
+	}
+
+	return 0;
+
+}
+
+int HID_API_EXPORT hid_read_timeout(hid_device *dev, unsigned char *data, size_t length, int milliseconds)
+{
+	int bytes_read = -1;
+
+	/* Lock the access to the report list. */
+	pthread_mutex_lock(&dev->mutex);
+
+	/* There's an input report queued up. Return it. */
+	if (dev->input_reports) {
+		/* Return the first one */
+		bytes_read = return_data(dev, data, length);
+		goto ret;
+	}
+
+	/* Return if the device has been disconnected. */
+	if (dev->disconnected) {
+		bytes_read = -1;
+		goto ret;
+	}
+
+	if (dev->shutdown_thread) {
+		/* This means the device has been closed (or there
+		   has been an error. An error code of -1 should
+		   be returned. */
+		bytes_read = -1;
+		goto ret;
+	}
+
+	/* There is no data. Go to sleep and wait for data. */
+
+	if (milliseconds == -1) {
+		/* Blocking */
+		int res;
+		res = cond_wait(dev, &dev->condition, &dev->mutex);
+		if (res == 0)
+			bytes_read = return_data(dev, data, length);
+		else {
+			/* There was an error, or a device disconnection. */
+			bytes_read = -1;
+		}
+	}
+	else if (milliseconds > 0) {
+		/* Non-blocking, but called with timeout. */
+		int res;
+		struct timespec ts;
+		struct timeval tv;
+		gettimeofday(&tv, NULL);
+		TIMEVAL_TO_TIMESPEC(&tv, &ts);
+		ts.tv_sec += milliseconds / 1000;
+		ts.tv_nsec += (milliseconds % 1000) * 1000000;
+		if (ts.tv_nsec >= 1000000000L) {
+			ts.tv_sec++;
+			ts.tv_nsec -= 1000000000L;
+		}
+
+		res = cond_timedwait(dev, &dev->condition, &dev->mutex, &ts);
+		if (res == 0)
+			bytes_read = return_data(dev, data, length);
+		else if (res == ETIMEDOUT)
+			bytes_read = 0;
+		else
+			bytes_read = -1;
+	}
+	else {
+		/* Purely non-blocking */
+		bytes_read = 0;
+	}
+
+ret:
+	/* Unlock */
+	pthread_mutex_unlock(&dev->mutex);
+	return bytes_read;
+}
+
+int HID_API_EXPORT hid_read(hid_device *dev, unsigned char *data, size_t length)
+{
+	return hid_read_timeout(dev, data, length, (dev->blocking)? -1: 0);
+}
+
+int HID_API_EXPORT hid_set_nonblocking(hid_device *dev, int nonblock)
+{
+	/* All Nonblocking operation is handled by the library. */
+	dev->blocking = !nonblock;
+
+	return 0;
+}
+
+int HID_API_EXPORT hid_send_feature_report(hid_device *dev, const unsigned char *data, size_t length)
+{
+	return set_report(dev, kIOHIDReportTypeFeature, data, length);
+}
+
+int HID_API_EXPORT hid_get_feature_report(hid_device *dev, unsigned char *data, size_t length)
+{
+	CFIndex len = length;
+	IOReturn res;
+
+	/* Return if the device has been unplugged. */
+	if (dev->disconnected)
+		return -1;
+
+	res = IOHIDDeviceGetReport(dev->device_handle,
+	                           kIOHIDReportTypeFeature,
+	                           data[0], /* Report ID */
+	                           data, &len);
+	if (res == kIOReturnSuccess)
+		return len;
+	else
+		return -1;
+}
+
+
+void HID_API_EXPORT hid_close(hid_device *dev)
+{
+	if (!dev)
+		return;
+
+	/* Disconnect the report callback before close. */
+	if (!dev->disconnected) {
+		IOHIDDeviceRegisterInputReportCallback(
+			dev->device_handle, dev->input_report_buf, dev->max_input_report_len,
+			NULL, dev);
+		IOHIDDeviceRegisterRemovalCallback(dev->device_handle, NULL, dev);
+		IOHIDDeviceUnscheduleFromRunLoop(dev->device_handle, dev->run_loop, dev->run_loop_mode);
+		IOHIDDeviceScheduleWithRunLoop(dev->device_handle, CFRunLoopGetMain(), kCFRunLoopDefaultMode);
+	}
+
+	/* Cause read_thread() to stop. */
+	dev->shutdown_thread = 1;
+
+	/* Wake up the run thread's event loop so that the thread can exit. */
+	CFRunLoopSourceSignal(dev->source);
+	CFRunLoopWakeUp(dev->run_loop);
+
+	/* Notify the read thread that it can shut down now. */
+	pthread_barrier_wait(&dev->shutdown_barrier);
+
+	/* Wait for read_thread() to end. */
+	pthread_join(dev->thread, NULL);
+
+	/* Close the OS handle to the device, but only if it's not
+	   been unplugged. If it's been unplugged, then calling
+	   IOHIDDeviceClose() will crash. */
+	if (!dev->disconnected) {
+		IOHIDDeviceClose(dev->device_handle, kIOHIDOptionsTypeSeizeDevice);
+	}
+
+	/* Clear out the queue of received reports. */
+	pthread_mutex_lock(&dev->mutex);
+	while (dev->input_reports) {
+		return_data(dev, NULL, 0);
+	}
+	pthread_mutex_unlock(&dev->mutex);
+	CFRelease(dev->device_handle);
+
+	free_hid_device(dev);
+}
+
+int HID_API_EXPORT_CALL hid_get_manufacturer_string(hid_device *dev, wchar_t *string, size_t maxlen)
+{
+	return get_manufacturer_string(dev->device_handle, string, maxlen);
+}
+
+int HID_API_EXPORT_CALL hid_get_product_string(hid_device *dev, wchar_t *string, size_t maxlen)
+{
+	return get_product_string(dev->device_handle, string, maxlen);
+}
+
+int HID_API_EXPORT_CALL hid_get_serial_number_string(hid_device *dev, wchar_t *string, size_t maxlen)
+{
+	return get_serial_number(dev->device_handle, string, maxlen);
+}
+
+int HID_API_EXPORT_CALL hid_get_indexed_string(hid_device *dev, int string_index, wchar_t *string, size_t maxlen)
+{
+	/* TODO: */
+
+	return 0;
+}
+
+
+HID_API_EXPORT const wchar_t * HID_API_CALL  hid_error(hid_device *dev)
+{
+	/* TODO: */
+
+	return NULL;
+}
+
+
+
+
+
+
+
+#if 0
+static int32_t get_usage(IOHIDDeviceRef device)
+{
+	int32_t res;
+	res = get_int_property(device, CFSTR(kIOHIDDeviceUsageKey));
+	if (!res)
+		res = get_int_property(device, CFSTR(kIOHIDPrimaryUsageKey));
+	return res;
+}
+
+static int32_t get_usage_page(IOHIDDeviceRef device)
+{
+	int32_t res;
+	res = get_int_property(device, CFSTR(kIOHIDDeviceUsagePageKey));
+	if (!res)
+		res = get_int_property(device, CFSTR(kIOHIDPrimaryUsagePageKey));
+	return res;
+}
+
+static int get_transport(IOHIDDeviceRef device, wchar_t *buf, size_t len)
+{
+	return get_string_property(device, CFSTR(kIOHIDTransportKey), buf, len);
+}
+
+
+int main(void)
+{
+	IOHIDManagerRef mgr;
+	int i;
+
+	mgr = IOHIDManagerCreate(kCFAllocatorDefault, kIOHIDOptionsTypeNone);
+	IOHIDManagerSetDeviceMatching(mgr, NULL);
+	IOHIDManagerOpen(mgr, kIOHIDOptionsTypeNone);
+
+	CFSetRef device_set = IOHIDManagerCopyDevices(mgr);
+
+	CFIndex num_devices = CFSetGetCount(device_set);
+	IOHIDDeviceRef *device_array = calloc(num_devices, sizeof(IOHIDDeviceRef));
+	CFSetGetValues(device_set, (const void **) device_array);
+
+	for (i = 0; i < num_devices; i++) {
+		IOHIDDeviceRef dev = device_array[i];
+		printf("Device: %p\n", dev);
+		printf("  %04hx %04hx\n", get_vendor_id(dev), get_product_id(dev));
+
+		wchar_t serial[256], buf[256];
+		char cbuf[256];
+		get_serial_number(dev, serial, 256);
+
+
+		printf("  Serial: %ls\n", serial);
+		printf("  Loc: %ld\n", get_location_id(dev));
+		get_transport(dev, buf, 256);
+		printf("  Trans: %ls\n", buf);
+		make_path(dev, cbuf, 256);
+		printf("  Path: %s\n", cbuf);
+
+	}
+
+	return 0;
+}
+#endif

--- a/hid_linux.c
+++ b/hid_linux.c
@@ -1,0 +1,1427 @@
+/*******************************************************
+ HIDAPI - Multi-Platform library for
+ communication with HID devices.
+
+ Alan Ott
+ Signal 11 Software
+
+ 8/22/2009
+ Linux Version - 6/2/2010
+ Libusb Version - 8/13/2010
+ FreeBSD Version - 11/1/2011
+
+ Copyright 2009, All Rights Reserved.
+
+ At the discretion of the user of this library,
+ this software may be licensed under the terms of the
+ GNU General Public License v3, a BSD-Style license, or the
+ original HIDAPI license as outlined in the LICENSE.txt,
+ LICENSE-gpl3.txt, LICENSE-bsd.txt, and LICENSE-orig.txt
+ files located at the root of the source distribution.
+ These files may also be found in the public source
+ code repository located at:
+        http://github.com/signal11/hidapi .
+********************************************************/
+
+#define _GNU_SOURCE /* needed for wcsdup() before glibc 2.10 */
+
+/* C */
+#include <stdio.h>
+#include <string.h>
+#include <stdlib.h>
+#include <ctype.h>
+#include <locale.h>
+#include <errno.h>
+
+/* Unix */
+#include <unistd.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <sys/ioctl.h>
+#include <sys/utsname.h>
+#include <fcntl.h>
+#include <pthread.h>
+#include <wchar.h>
+
+/* GNU / LibUSB */
+#include "libusb.h"
+#include "iconv.h"
+
+#include "hidapi.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#ifdef DEBUG_PRINTF
+#define LOG(...) fprintf(stderr, __VA_ARGS__)
+#else
+#define LOG(...) do {} while (0)
+#endif
+
+#ifndef __FreeBSD__
+#define DETACH_KERNEL_DRIVER
+#endif
+
+/* Uncomment to enable the retrieval of Usage and Usage Page in
+hid_enumerate(). Warning, on platforms different from FreeBSD
+this is very invasive as it requires the detach
+and re-attach of the kernel driver. See comments inside hid_enumerate().
+libusb HIDAPI programs are encouraged to use the interface number
+instead to differentiate between interfaces on a composite HID device. */
+/*#define INVASIVE_GET_USAGE*/
+
+/* Linked List of input reports received from the device. */
+struct input_report {
+	uint8_t *data;
+	size_t len;
+	struct input_report *next;
+};
+
+
+struct hid_device_ {
+	/* Handle to the actual device. */
+	libusb_device_handle *device_handle;
+
+	/* Endpoint information */
+	int input_endpoint;
+	int output_endpoint;
+	int input_ep_max_packet_size;
+
+	/* The interface number of the HID */
+	int interface;
+
+	/* Indexes of Strings */
+	int manufacturer_index;
+	int product_index;
+	int serial_index;
+
+	/* Whether blocking reads are used */
+	int blocking; /* boolean */
+
+	/* Read thread objects */
+	pthread_t thread;
+	pthread_mutex_t mutex; /* Protects input_reports */
+	pthread_cond_t condition;
+	pthread_barrier_t barrier; /* Ensures correct startup sequence */
+	int shutdown_thread;
+	int cancelled;
+	struct libusb_transfer *transfer;
+
+	/* List of received input reports. */
+	struct input_report *input_reports;
+};
+
+static libusb_context *usb_context = NULL;
+
+uint16_t get_usb_code_for_current_locale(void);
+static int return_data(hid_device *dev, unsigned char *data, size_t length);
+
+static hid_device *new_hid_device(void)
+{
+	hid_device *dev = calloc(1, sizeof(hid_device));
+	dev->blocking = 1;
+
+	pthread_mutex_init(&dev->mutex, NULL);
+	pthread_cond_init(&dev->condition, NULL);
+	pthread_barrier_init(&dev->barrier, NULL, 2);
+
+	return dev;
+}
+
+static void free_hid_device(hid_device *dev)
+{
+	/* Clean up the thread objects */
+	pthread_barrier_destroy(&dev->barrier);
+	pthread_cond_destroy(&dev->condition);
+	pthread_mutex_destroy(&dev->mutex);
+
+	/* Free the device itself */
+	free(dev);
+}
+
+#if 0
+/*TODO: Implement this funciton on hidapi/libusb.. */
+static void register_error(hid_device *device, const char *op)
+{
+
+}
+#endif
+
+#ifdef INVASIVE_GET_USAGE
+/* Get bytes from a HID Report Descriptor.
+   Only call with a num_bytes of 0, 1, 2, or 4. */
+static uint32_t get_bytes(uint8_t *rpt, size_t len, size_t num_bytes, size_t cur)
+{
+	/* Return if there aren't enough bytes. */
+	if (cur + num_bytes >= len)
+		return 0;
+
+	if (num_bytes == 0)
+		return 0;
+	else if (num_bytes == 1) {
+		return rpt[cur+1];
+	}
+	else if (num_bytes == 2) {
+		return (rpt[cur+2] * 256 + rpt[cur+1]);
+	}
+	else if (num_bytes == 4) {
+		return (rpt[cur+4] * 0x01000000 +
+		        rpt[cur+3] * 0x00010000 +
+		        rpt[cur+2] * 0x00000100 +
+		        rpt[cur+1] * 0x00000001);
+	}
+	else
+		return 0;
+}
+
+/* Retrieves the device's Usage Page and Usage from the report
+   descriptor. The algorithm is simple, as it just returns the first
+   Usage and Usage Page that it finds in the descriptor.
+   The return value is 0 on success and -1 on failure. */
+static int get_usage(uint8_t *report_descriptor, size_t size,
+                     unsigned short *usage_page, unsigned short *usage)
+{
+	unsigned int i = 0;
+	int size_code;
+	int data_len, key_size;
+	int usage_found = 0, usage_page_found = 0;
+
+	while (i < size) {
+		int key = report_descriptor[i];
+		int key_cmd = key & 0xfc;
+
+		//printf("key: %02hhx\n", key);
+
+		if ((key & 0xf0) == 0xf0) {
+			/* This is a Long Item. The next byte contains the
+			   length of the data section (value) for this key.
+			   See the HID specification, version 1.11, section
+			   6.2.2.3, titled "Long Items." */
+			if (i+1 < size)
+				data_len = report_descriptor[i+1];
+			else
+				data_len = 0; /* malformed report */
+			key_size = 3;
+		}
+		else {
+			/* This is a Short Item. The bottom two bits of the
+			   key contain the size code for the data section
+			   (value) for this key.  Refer to the HID
+			   specification, version 1.11, section 6.2.2.2,
+			   titled "Short Items." */
+			size_code = key & 0x3;
+			switch (size_code) {
+			case 0:
+			case 1:
+			case 2:
+				data_len = size_code;
+				break;
+			case 3:
+				data_len = 4;
+				break;
+			default:
+				/* Can't ever happen since size_code is & 0x3 */
+				data_len = 0;
+				break;
+			};
+			key_size = 1;
+		}
+
+		if (key_cmd == 0x4) {
+			*usage_page  = get_bytes(report_descriptor, size, data_len, i);
+			usage_page_found = 1;
+			//printf("Usage Page: %x\n", (uint32_t)*usage_page);
+		}
+		if (key_cmd == 0x8) {
+			*usage = get_bytes(report_descriptor, size, data_len, i);
+			usage_found = 1;
+			//printf("Usage: %x\n", (uint32_t)*usage);
+		}
+
+		if (usage_page_found && usage_found)
+			return 0; /* success */
+
+		/* Skip over this key and it's associated data */
+		i += data_len + key_size;
+	}
+
+	return -1; /* failure */
+}
+#endif /* INVASIVE_GET_USAGE */
+
+#ifdef __FreeBSD__
+/* The FreeBSD version of libusb doesn't have this funciton. In mainline
+   libusb, it's inlined in libusb.h. This function will bear a striking
+   resemblence to that one, because there's about one way to code it.
+
+   Note that the data parameter is Unicode in UTF-16LE encoding.
+   Return value is the number of bytes in data, or LIBUSB_ERROR_*.
+ */
+static inline int libusb_get_string_descriptor(libusb_device_handle *dev,
+	uint8_t descriptor_index, uint16_t lang_id,
+	unsigned char *data, int length)
+{
+	return libusb_control_transfer(dev,
+		LIBUSB_ENDPOINT_IN | 0x0, /* Endpoint 0 IN */
+		LIBUSB_REQUEST_GET_DESCRIPTOR,
+		(LIBUSB_DT_STRING << 8) | descriptor_index,
+		lang_id, data, (uint16_t) length, 1000);
+}
+
+#endif
+
+
+/* Get the first language the device says it reports. This comes from
+   USB string #0. */
+static uint16_t get_first_language(libusb_device_handle *dev)
+{
+	uint16_t buf[32];
+	int len;
+
+	/* Get the string from libusb. */
+	len = libusb_get_string_descriptor(dev,
+			0x0, /* String ID */
+			0x0, /* Language */
+			(unsigned char*)buf,
+			sizeof(buf));
+	if (len < 4)
+		return 0x0;
+
+	return buf[1]; /* First two bytes are len and descriptor type. */
+}
+
+static int is_language_supported(libusb_device_handle *dev, uint16_t lang)
+{
+	uint16_t buf[32];
+	int len;
+	int i;
+
+	/* Get the string from libusb. */
+	len = libusb_get_string_descriptor(dev,
+			0x0, /* String ID */
+			0x0, /* Language */
+			(unsigned char*)buf,
+			sizeof(buf));
+	if (len < 4)
+		return 0x0;
+
+
+	len /= 2; /* language IDs are two-bytes each. */
+	/* Start at index 1 because there are two bytes of protocol data. */
+	for (i = 1; i < len; i++) {
+		if (buf[i] == lang)
+			return 1;
+	}
+
+	return 0;
+}
+
+
+/* This function returns a newly allocated wide string containing the USB
+   device string numbered by the index. The returned string must be freed
+   by using free(). */
+static wchar_t *get_usb_string(libusb_device_handle *dev, uint8_t idx)
+{
+	char buf[512];
+	int len;
+	wchar_t *str = NULL;
+	wchar_t wbuf[256];
+
+	/* iconv variables */
+	iconv_t ic;
+	size_t inbytes;
+	size_t outbytes;
+	size_t res;
+#ifdef __FreeBSD__
+	const char *inptr;
+#else
+	char *inptr;
+#endif
+	char *outptr;
+
+	/* Determine which language to use. */
+	uint16_t lang;
+	lang = get_usb_code_for_current_locale();
+	if (!is_language_supported(dev, lang))
+		lang = get_first_language(dev);
+
+	/* Get the string from libusb. */
+	len = libusb_get_string_descriptor(dev,
+			idx,
+			lang,
+			(unsigned char*)buf,
+			sizeof(buf));
+	if (len < 0)
+		return NULL;
+
+	/* buf does not need to be explicitly NULL-terminated because
+	   it is only passed into iconv() which does not need it. */
+
+	/* Initialize iconv. */
+	ic = iconv_open("WCHAR_T", "UTF-16LE");
+	if (ic == (iconv_t)-1) {
+		LOG("iconv_open() failed\n");
+		return NULL;
+	}
+
+	/* Convert to native wchar_t (UTF-32 on glibc/BSD systems).
+	   Skip the first character (2-bytes). */
+	inptr = buf+2;
+	inbytes = len-2;
+	outptr = (char*) wbuf;
+	outbytes = sizeof(wbuf);
+	res = iconv(ic, &inptr, &inbytes, &outptr, &outbytes);
+	if (res == (size_t)-1) {
+		LOG("iconv() failed\n");
+		goto err;
+	}
+
+	/* Write the terminating NULL. */
+	wbuf[sizeof(wbuf)/sizeof(wbuf[0])-1] = 0x00000000;
+	if (outbytes >= sizeof(wbuf[0]))
+		*((wchar_t*)outptr) = 0x00000000;
+
+	/* Allocate and copy the string. */
+	str = wcsdup(wbuf);
+
+err:
+	iconv_close(ic);
+
+	return str;
+}
+
+static char *make_path(libusb_device *dev, int interface_number)
+{
+	char str[64];
+	snprintf(str, sizeof(str), "%04x:%04x:%02x",
+		libusb_get_bus_number(dev),
+		libusb_get_device_address(dev),
+		interface_number);
+	str[sizeof(str)-1] = '\0';
+
+	return strdup(str);
+}
+
+
+int HID_API_EXPORT hid_init(void)
+{
+	if (!usb_context) {
+		const char *locale;
+
+		/* Init Libusb */
+		if (libusb_init(&usb_context))
+			return -1;
+
+		/* Set the locale if it's not set. */
+		locale = setlocale(LC_CTYPE, NULL);
+		if (!locale)
+			setlocale(LC_CTYPE, "");
+	}
+
+	return 0;
+}
+
+int HID_API_EXPORT hid_exit(void)
+{
+	if (usb_context) {
+		libusb_exit(usb_context);
+		usb_context = NULL;
+	}
+
+	return 0;
+}
+
+struct hid_device_info  HID_API_EXPORT *hid_enumerate(unsigned short vendor_id, unsigned short product_id)
+{
+	libusb_device **devs;
+	libusb_device *dev;
+	libusb_device_handle *handle;
+	ssize_t num_devs;
+	int i = 0;
+
+	struct hid_device_info *root = NULL; /* return object */
+	struct hid_device_info *cur_dev = NULL;
+
+	if(hid_init() < 0)
+		return NULL;
+
+	num_devs = libusb_get_device_list(usb_context, &devs);
+	if (num_devs < 0)
+		return NULL;
+	while ((dev = devs[i++]) != NULL) {
+		struct libusb_device_descriptor desc;
+		struct libusb_config_descriptor *conf_desc = NULL;
+		int j, k;
+		int interface_num = 0;
+
+		int res = libusb_get_device_descriptor(dev, &desc);
+		unsigned short dev_vid = desc.idVendor;
+		unsigned short dev_pid = desc.idProduct;
+
+		res = libusb_get_active_config_descriptor(dev, &conf_desc);
+		if (res < 0)
+			libusb_get_config_descriptor(dev, 0, &conf_desc);
+		if (conf_desc) {
+			for (j = 0; j < conf_desc->bNumInterfaces; j++) {
+				const struct libusb_interface *intf = &conf_desc->interface[j];
+				for (k = 0; k < intf->num_altsetting; k++) {
+					const struct libusb_interface_descriptor *intf_desc;
+					intf_desc = &intf->altsetting[k];
+					if (intf_desc->bInterfaceClass == LIBUSB_CLASS_HID) {
+						interface_num = intf_desc->bInterfaceNumber;
+
+						/* Check the VID/PID against the arguments */
+						if ((vendor_id == 0x0 || vendor_id == dev_vid) &&
+						    (product_id == 0x0 || product_id == dev_pid)) {
+							struct hid_device_info *tmp;
+
+							/* VID/PID match. Create the record. */
+							tmp = calloc(1, sizeof(struct hid_device_info));
+							if (cur_dev) {
+								cur_dev->next = tmp;
+							}
+							else {
+								root = tmp;
+							}
+							cur_dev = tmp;
+
+							/* Fill out the record */
+							cur_dev->next = NULL;
+							cur_dev->path = make_path(dev, interface_num);
+
+							res = libusb_open(dev, &handle);
+
+							if (res >= 0) {
+								/* Serial Number */
+								if (desc.iSerialNumber > 0)
+									cur_dev->serial_number =
+										get_usb_string(handle, desc.iSerialNumber);
+
+								/* Manufacturer and Product strings */
+								if (desc.iManufacturer > 0)
+									cur_dev->manufacturer_string =
+										get_usb_string(handle, desc.iManufacturer);
+								if (desc.iProduct > 0)
+									cur_dev->product_string =
+										get_usb_string(handle, desc.iProduct);
+
+#ifdef INVASIVE_GET_USAGE
+{
+							/*
+							This section is removed because it is too
+							invasive on the system. Getting a Usage Page
+							and Usage requires parsing the HID Report
+							descriptor. Getting a HID Report descriptor
+							involves claiming the interface. Claiming the
+							interface involves detaching the kernel driver.
+							Detaching the kernel driver is hard on the system
+							because it will unclaim interfaces (if another
+							app has them claimed) and the re-attachment of
+							the driver will sometimes change /dev entry names.
+							It is for these reasons that this section is
+							#if 0. For composite devices, use the interface
+							field in the hid_device_info struct to distinguish
+							between interfaces. */
+								unsigned char data[256];
+#ifdef DETACH_KERNEL_DRIVER
+								int detached = 0;
+								/* Usage Page and Usage */
+								res = libusb_kernel_driver_active(handle, interface_num);
+								if (res == 1) {
+									res = libusb_detach_kernel_driver(handle, interface_num);
+									if (res < 0)
+										LOG("Couldn't detach kernel driver, even though a kernel driver was attached.");
+									else
+										detached = 1;
+								}
+#endif
+								res = libusb_claim_interface(handle, interface_num);
+								if (res >= 0) {
+									/* Get the HID Report Descriptor. */
+									res = libusb_control_transfer(handle, LIBUSB_ENDPOINT_IN|LIBUSB_RECIPIENT_INTERFACE, LIBUSB_REQUEST_GET_DESCRIPTOR, (LIBUSB_DT_REPORT << 8)|interface_num, 0, data, sizeof(data), 5000);
+									if (res >= 0) {
+										unsigned short page=0, usage=0;
+										/* Parse the usage and usage page
+										   out of the report descriptor. */
+										get_usage(data, res,  &page, &usage);
+										cur_dev->usage_page = page;
+										cur_dev->usage = usage;
+									}
+									else
+										LOG("libusb_control_transfer() for getting the HID report failed with %d\n", res);
+
+									/* Release the interface */
+									res = libusb_release_interface(handle, interface_num);
+									if (res < 0)
+										LOG("Can't release the interface.\n");
+								}
+								else
+									LOG("Can't claim interface %d\n", res);
+#ifdef DETACH_KERNEL_DRIVER
+								/* Re-attach kernel driver if necessary. */
+								if (detached) {
+									res = libusb_attach_kernel_driver(handle, interface_num);
+									if (res < 0)
+										LOG("Couldn't re-attach kernel driver.\n");
+								}
+#endif
+}
+#endif /* INVASIVE_GET_USAGE */
+
+								libusb_close(handle);
+							}
+							/* VID/PID */
+							cur_dev->vendor_id = dev_vid;
+							cur_dev->product_id = dev_pid;
+
+							/* Release Number */
+							cur_dev->release_number = desc.bcdDevice;
+
+							/* Interface Number */
+							cur_dev->interface_number = interface_num;
+						}
+					}
+				} /* altsettings */
+			} /* interfaces */
+			libusb_free_config_descriptor(conf_desc);
+		}
+	}
+
+	libusb_free_device_list(devs, 1);
+
+	return root;
+}
+
+void  HID_API_EXPORT hid_free_enumeration(struct hid_device_info *devs)
+{
+	struct hid_device_info *d = devs;
+	while (d) {
+		struct hid_device_info *next = d->next;
+		free(d->path);
+		free(d->serial_number);
+		free(d->manufacturer_string);
+		free(d->product_string);
+		free(d);
+		d = next;
+	}
+}
+
+hid_device * hid_open(unsigned short vendor_id, unsigned short product_id, const wchar_t *serial_number)
+{
+	struct hid_device_info *devs, *cur_dev;
+	const char *path_to_open = NULL;
+	hid_device *handle = NULL;
+
+	devs = hid_enumerate(vendor_id, product_id);
+	cur_dev = devs;
+	while (cur_dev) {
+		if (cur_dev->vendor_id == vendor_id &&
+		    cur_dev->product_id == product_id) {
+			if (serial_number) {
+				if (wcscmp(serial_number, cur_dev->serial_number) == 0) {
+					path_to_open = cur_dev->path;
+					break;
+				}
+			}
+			else {
+				path_to_open = cur_dev->path;
+				break;
+			}
+		}
+		cur_dev = cur_dev->next;
+	}
+
+	if (path_to_open) {
+		/* Open the device */
+		handle = hid_open_path(path_to_open);
+	}
+
+	hid_free_enumeration(devs);
+
+	return handle;
+}
+
+static void read_callback(struct libusb_transfer *transfer)
+{
+	hid_device *dev = transfer->user_data;
+	int res;
+
+	if (transfer->status == LIBUSB_TRANSFER_COMPLETED) {
+
+		struct input_report *rpt = malloc(sizeof(*rpt));
+		rpt->data = malloc(transfer->actual_length);
+		memcpy(rpt->data, transfer->buffer, transfer->actual_length);
+		rpt->len = transfer->actual_length;
+		rpt->next = NULL;
+
+		pthread_mutex_lock(&dev->mutex);
+
+		/* Attach the new report object to the end of the list. */
+		if (dev->input_reports == NULL) {
+			/* The list is empty. Put it at the root. */
+			dev->input_reports = rpt;
+			pthread_cond_signal(&dev->condition);
+		}
+		else {
+			/* Find the end of the list and attach. */
+			struct input_report *cur = dev->input_reports;
+			int num_queued = 0;
+			while (cur->next != NULL) {
+				cur = cur->next;
+				num_queued++;
+			}
+			cur->next = rpt;
+
+			/* Pop one off if we've reached 30 in the queue. This
+			   way we don't grow forever if the user never reads
+			   anything from the device. */
+			if (num_queued > 30) {
+				return_data(dev, NULL, 0);
+			}
+		}
+		pthread_mutex_unlock(&dev->mutex);
+	}
+	else if (transfer->status == LIBUSB_TRANSFER_CANCELLED) {
+		dev->shutdown_thread = 1;
+		dev->cancelled = 1;
+		return;
+	}
+	else if (transfer->status == LIBUSB_TRANSFER_NO_DEVICE) {
+		dev->shutdown_thread = 1;
+		dev->cancelled = 1;
+		return;
+	}
+	else if (transfer->status == LIBUSB_TRANSFER_TIMED_OUT) {
+		//LOG("Timeout (normal)\n");
+	}
+	else {
+		LOG("Unknown transfer code: %d\n", transfer->status);
+	}
+
+	/* Re-submit the transfer object. */
+	res = libusb_submit_transfer(transfer);
+	if (res != 0) {
+		LOG("Unable to submit URB. libusb error code: %d\n", res);
+		dev->shutdown_thread = 1;
+		dev->cancelled = 1;
+	}
+}
+
+
+static void *read_thread(void *param)
+{
+	hid_device *dev = param;
+	unsigned char *buf;
+	const size_t length = dev->input_ep_max_packet_size;
+
+	/* Set up the transfer object. */
+	buf = malloc(length);
+	dev->transfer = libusb_alloc_transfer(0);
+	libusb_fill_interrupt_transfer(dev->transfer,
+		dev->device_handle,
+		dev->input_endpoint,
+		buf,
+		length,
+		read_callback,
+		dev,
+		5000/*timeout*/);
+
+	/* Make the first submission. Further submissions are made
+	   from inside read_callback() */
+	libusb_submit_transfer(dev->transfer);
+
+	/* Notify the main thread that the read thread is up and running. */
+	pthread_barrier_wait(&dev->barrier);
+
+	/* Handle all the events. */
+	while (!dev->shutdown_thread) {
+		int res;
+		res = libusb_handle_events(usb_context);
+		if (res < 0) {
+			/* There was an error. */
+			LOG("read_thread(): libusb reports error # %d\n", res);
+
+			/* Break out of this loop only on fatal error.*/
+			if (res != LIBUSB_ERROR_BUSY &&
+			    res != LIBUSB_ERROR_TIMEOUT &&
+			    res != LIBUSB_ERROR_OVERFLOW &&
+			    res != LIBUSB_ERROR_INTERRUPTED) {
+				break;
+			}
+		}
+	}
+
+	/* Cancel any transfer that may be pending. This call will fail
+	   if no transfers are pending, but that's OK. */
+	libusb_cancel_transfer(dev->transfer);
+
+	while (!dev->cancelled)
+		libusb_handle_events_completed(usb_context, &dev->cancelled);
+
+	/* Now that the read thread is stopping, Wake any threads which are
+	   waiting on data (in hid_read_timeout()). Do this under a mutex to
+	   make sure that a thread which is about to go to sleep waiting on
+	   the condition acutally will go to sleep before the condition is
+	   signaled. */
+	pthread_mutex_lock(&dev->mutex);
+	pthread_cond_broadcast(&dev->condition);
+	pthread_mutex_unlock(&dev->mutex);
+
+	/* The dev->transfer->buffer and dev->transfer objects are cleaned up
+	   in hid_close(). They are not cleaned up here because this thread
+	   could end either due to a disconnect or due to a user
+	   call to hid_close(). In both cases the objects can be safely
+	   cleaned up after the call to pthread_join() (in hid_close()), but
+	   since hid_close() calls libusb_cancel_transfer(), on these objects,
+	   they can not be cleaned up here. */
+
+	return NULL;
+}
+
+
+hid_device * HID_API_EXPORT hid_open_path(const char *path)
+{
+	hid_device *dev = NULL;
+
+	libusb_device **devs;
+	libusb_device *usb_dev;
+	int res;
+	int d = 0;
+	int good_open = 0;
+
+	if(hid_init() < 0)
+		return NULL;
+
+	dev = new_hid_device();
+
+	libusb_get_device_list(usb_context, &devs);
+	while ((usb_dev = devs[d++]) != NULL) {
+		struct libusb_device_descriptor desc;
+		struct libusb_config_descriptor *conf_desc = NULL;
+		int i,j,k;
+		libusb_get_device_descriptor(usb_dev, &desc);
+
+		if (libusb_get_active_config_descriptor(usb_dev, &conf_desc) < 0)
+			continue;
+		for (j = 0; j < conf_desc->bNumInterfaces; j++) {
+			const struct libusb_interface *intf = &conf_desc->interface[j];
+			for (k = 0; k < intf->num_altsetting; k++) {
+				const struct libusb_interface_descriptor *intf_desc;
+				intf_desc = &intf->altsetting[k];
+				if (intf_desc->bInterfaceClass == LIBUSB_CLASS_HID) {
+					char *dev_path = make_path(usb_dev, intf_desc->bInterfaceNumber);
+					if (!strcmp(dev_path, path)) {
+						/* Matched Paths. Open this device */
+
+						/* OPEN HERE */
+						res = libusb_open(usb_dev, &dev->device_handle);
+						if (res < 0) {
+							LOG("can't open device\n");
+							free(dev_path);
+							break;
+						}
+						good_open = 1;
+#ifdef DETACH_KERNEL_DRIVER
+						/* Detach the kernel driver, but only if the
+						   device is managed by the kernel */
+						if (libusb_kernel_driver_active(dev->device_handle, intf_desc->bInterfaceNumber) == 1) {
+							res = libusb_detach_kernel_driver(dev->device_handle, intf_desc->bInterfaceNumber);
+							if (res < 0) {
+								libusb_close(dev->device_handle);
+								LOG("Unable to detach Kernel Driver\n");
+								free(dev_path);
+								good_open = 0;
+								break;
+							}
+						}
+#endif
+						res = libusb_claim_interface(dev->device_handle, intf_desc->bInterfaceNumber);
+						if (res < 0) {
+							LOG("can't claim interface %d: %d\n", intf_desc->bInterfaceNumber, res);
+							free(dev_path);
+							libusb_close(dev->device_handle);
+							good_open = 0;
+							break;
+						}
+
+						/* Store off the string descriptor indexes */
+						dev->manufacturer_index = desc.iManufacturer;
+						dev->product_index      = desc.iProduct;
+						dev->serial_index       = desc.iSerialNumber;
+
+						/* Store off the interface number */
+						dev->interface = intf_desc->bInterfaceNumber;
+
+						/* Find the INPUT and OUTPUT endpoints. An
+						   OUTPUT endpoint is not required. */
+						for (i = 0; i < intf_desc->bNumEndpoints; i++) {
+							const struct libusb_endpoint_descriptor *ep
+								= &intf_desc->endpoint[i];
+
+							/* Determine the type and direction of this
+							   endpoint. */
+							int is_interrupt =
+								(ep->bmAttributes & LIBUSB_TRANSFER_TYPE_MASK)
+							      == LIBUSB_TRANSFER_TYPE_INTERRUPT;
+							int is_output =
+								(ep->bEndpointAddress & LIBUSB_ENDPOINT_DIR_MASK)
+							      == LIBUSB_ENDPOINT_OUT;
+							int is_input =
+								(ep->bEndpointAddress & LIBUSB_ENDPOINT_DIR_MASK)
+							      == LIBUSB_ENDPOINT_IN;
+
+							/* Decide whether to use it for intput or output. */
+							if (dev->input_endpoint == 0 &&
+							    is_interrupt && is_input) {
+								/* Use this endpoint for INPUT */
+								dev->input_endpoint = ep->bEndpointAddress;
+								dev->input_ep_max_packet_size = ep->wMaxPacketSize;
+							}
+							if (dev->output_endpoint == 0 &&
+							    is_interrupt && is_output) {
+								/* Use this endpoint for OUTPUT */
+								dev->output_endpoint = ep->bEndpointAddress;
+							}
+						}
+
+						pthread_create(&dev->thread, NULL, read_thread, dev);
+
+						/* Wait here for the read thread to be initialized. */
+						pthread_barrier_wait(&dev->barrier);
+
+					}
+					free(dev_path);
+				}
+			}
+		}
+		libusb_free_config_descriptor(conf_desc);
+
+	}
+
+	libusb_free_device_list(devs, 1);
+
+	/* If we have a good handle, return it. */
+	if (good_open) {
+		return dev;
+	}
+	else {
+		/* Unable to open any devices. */
+		free_hid_device(dev);
+		return NULL;
+	}
+}
+
+
+int HID_API_EXPORT hid_write(hid_device *dev, const unsigned char *data, size_t length)
+{
+	int res;
+	int report_number = data[0];
+	int skipped_report_id = 0;
+
+	if (report_number == 0x0) {
+		data++;
+		length--;
+		skipped_report_id = 1;
+	}
+
+
+	if (dev->output_endpoint <= 0) {
+		/* No interrput out endpoint. Use the Control Endpoint */
+		res = libusb_control_transfer(dev->device_handle,
+			LIBUSB_REQUEST_TYPE_CLASS|LIBUSB_RECIPIENT_INTERFACE|LIBUSB_ENDPOINT_OUT,
+			0x09/*HID Set_Report*/,
+			(2/*HID output*/ << 8) | report_number,
+			dev->interface,
+			(unsigned char *)data, length,
+			1000/*timeout millis*/);
+
+		if (res < 0)
+			return -1;
+
+		if (skipped_report_id)
+			length++;
+
+		return length;
+	}
+	else {
+		/* Use the interrupt out endpoint */
+		int actual_length;
+		res = libusb_interrupt_transfer(dev->device_handle,
+			dev->output_endpoint,
+			(unsigned char*)data,
+			length,
+			&actual_length, 1000);
+
+		if (res < 0)
+			return -1;
+
+		if (skipped_report_id)
+			actual_length++;
+
+		return actual_length;
+	}
+}
+
+/* Helper function, to simplify hid_read().
+   This should be called with dev->mutex locked. */
+static int return_data(hid_device *dev, unsigned char *data, size_t length)
+{
+	/* Copy the data out of the linked list item (rpt) into the
+	   return buffer (data), and delete the liked list item. */
+	struct input_report *rpt = dev->input_reports;
+	size_t len = (length < rpt->len)? length: rpt->len;
+	if (len > 0)
+		memcpy(data, rpt->data, len);
+	dev->input_reports = rpt->next;
+	free(rpt->data);
+	free(rpt);
+	return len;
+}
+
+static void cleanup_mutex(void *param)
+{
+	hid_device *dev = param;
+	pthread_mutex_unlock(&dev->mutex);
+}
+
+
+int HID_API_EXPORT hid_read_timeout(hid_device *dev, unsigned char *data, size_t length, int milliseconds)
+{
+	int bytes_read = -1;
+
+#if 0
+	int transferred;
+	int res = libusb_interrupt_transfer(dev->device_handle, dev->input_endpoint, data, length, &transferred, 5000);
+	LOG("transferred: %d\n", transferred);
+	return transferred;
+#endif
+
+	pthread_mutex_lock(&dev->mutex);
+	pthread_cleanup_push(&cleanup_mutex, dev);
+
+	/* There's an input report queued up. Return it. */
+	if (dev->input_reports) {
+		/* Return the first one */
+		bytes_read = return_data(dev, data, length);
+		goto ret;
+	}
+
+	if (dev->shutdown_thread) {
+		/* This means the device has been disconnected.
+		   An error code of -1 should be returned. */
+		bytes_read = -1;
+		goto ret;
+	}
+
+	if (milliseconds == -1) {
+		/* Blocking */
+		while (!dev->input_reports && !dev->shutdown_thread) {
+			pthread_cond_wait(&dev->condition, &dev->mutex);
+		}
+		if (dev->input_reports) {
+			bytes_read = return_data(dev, data, length);
+		}
+	}
+	else if (milliseconds > 0) {
+		/* Non-blocking, but called with timeout. */
+		int res;
+		struct timespec ts;
+		clock_gettime(CLOCK_REALTIME, &ts);
+		ts.tv_sec += milliseconds / 1000;
+		ts.tv_nsec += (milliseconds % 1000) * 1000000;
+		if (ts.tv_nsec >= 1000000000L) {
+			ts.tv_sec++;
+			ts.tv_nsec -= 1000000000L;
+		}
+
+		while (!dev->input_reports && !dev->shutdown_thread) {
+			res = pthread_cond_timedwait(&dev->condition, &dev->mutex, &ts);
+			if (res == 0) {
+				if (dev->input_reports) {
+					bytes_read = return_data(dev, data, length);
+					break;
+				}
+
+				/* If we're here, there was a spurious wake up
+				   or the read thread was shutdown. Run the
+				   loop again (ie: don't break). */
+			}
+			else if (res == ETIMEDOUT) {
+				/* Timed out. */
+				bytes_read = 0;
+				break;
+			}
+			else {
+				/* Error. */
+				bytes_read = -1;
+				break;
+			}
+		}
+	}
+	else {
+		/* Purely non-blocking */
+		bytes_read = 0;
+	}
+
+ret:
+	pthread_mutex_unlock(&dev->mutex);
+	pthread_cleanup_pop(0);
+
+	return bytes_read;
+}
+
+int HID_API_EXPORT hid_read(hid_device *dev, unsigned char *data, size_t length)
+{
+	return hid_read_timeout(dev, data, length, dev->blocking ? -1 : 0);
+}
+
+int HID_API_EXPORT hid_set_nonblocking(hid_device *dev, int nonblock)
+{
+	dev->blocking = !nonblock;
+
+	return 0;
+}
+
+
+int HID_API_EXPORT hid_send_feature_report(hid_device *dev, const unsigned char *data, size_t length)
+{
+	int res = -1;
+	int skipped_report_id = 0;
+	int report_number = data[0];
+
+	if (report_number == 0x0) {
+		data++;
+		length--;
+		skipped_report_id = 1;
+	}
+
+	res = libusb_control_transfer(dev->device_handle,
+		LIBUSB_REQUEST_TYPE_CLASS|LIBUSB_RECIPIENT_INTERFACE|LIBUSB_ENDPOINT_OUT,
+		0x09/*HID set_report*/,
+		(3/*HID feature*/ << 8) | report_number,
+		dev->interface,
+		(unsigned char *)data, length,
+		1000/*timeout millis*/);
+
+	if (res < 0)
+		return -1;
+
+	/* Account for the report ID */
+	if (skipped_report_id)
+		length++;
+
+	return length;
+}
+
+int HID_API_EXPORT hid_get_feature_report(hid_device *dev, unsigned char *data, size_t length)
+{
+	int res = -1;
+	int skipped_report_id = 0;
+	int report_number = data[0];
+
+	if (report_number == 0x0) {
+		/* Offset the return buffer by 1, so that the report ID
+		   will remain in byte 0. */
+		data++;
+		length--;
+		skipped_report_id = 1;
+	}
+	res = libusb_control_transfer(dev->device_handle,
+		LIBUSB_REQUEST_TYPE_CLASS|LIBUSB_RECIPIENT_INTERFACE|LIBUSB_ENDPOINT_IN,
+		0x01/*HID get_report*/,
+		(3/*HID feature*/ << 8) | report_number,
+		dev->interface,
+		(unsigned char *)data, length,
+		1000/*timeout millis*/);
+
+	if (res < 0)
+		return -1;
+
+	if (skipped_report_id)
+		res++;
+
+	return res;
+}
+
+
+void HID_API_EXPORT hid_close(hid_device *dev)
+{
+	if (!dev)
+		return;
+
+	/* Cause read_thread() to stop. */
+	dev->shutdown_thread = 1;
+	libusb_cancel_transfer(dev->transfer);
+
+	/* Wait for read_thread() to end. */
+	pthread_join(dev->thread, NULL);
+
+	/* Clean up the Transfer objects allocated in read_thread(). */
+	free(dev->transfer->buffer);
+	libusb_free_transfer(dev->transfer);
+
+	/* release the interface */
+	libusb_release_interface(dev->device_handle, dev->interface);
+
+	/* Close the handle */
+	libusb_close(dev->device_handle);
+
+	/* Clear out the queue of received reports. */
+	pthread_mutex_lock(&dev->mutex);
+	while (dev->input_reports) {
+		return_data(dev, NULL, 0);
+	}
+	pthread_mutex_unlock(&dev->mutex);
+
+	free_hid_device(dev);
+}
+
+
+int HID_API_EXPORT_CALL hid_get_manufacturer_string(hid_device *dev, wchar_t *string, size_t maxlen)
+{
+	return hid_get_indexed_string(dev, dev->manufacturer_index, string, maxlen);
+}
+
+int HID_API_EXPORT_CALL hid_get_product_string(hid_device *dev, wchar_t *string, size_t maxlen)
+{
+	return hid_get_indexed_string(dev, dev->product_index, string, maxlen);
+}
+
+int HID_API_EXPORT_CALL hid_get_serial_number_string(hid_device *dev, wchar_t *string, size_t maxlen)
+{
+	return hid_get_indexed_string(dev, dev->serial_index, string, maxlen);
+}
+
+int HID_API_EXPORT_CALL hid_get_indexed_string(hid_device *dev, int string_index, wchar_t *string, size_t maxlen)
+{
+	wchar_t *str;
+
+	str = get_usb_string(dev->device_handle, string_index);
+	if (str) {
+		wcsncpy(string, str, maxlen);
+		string[maxlen-1] = L'\0';
+		free(str);
+		return 0;
+	}
+	else
+		return -1;
+}
+
+
+HID_API_EXPORT const wchar_t * HID_API_CALL  hid_error(hid_device *dev)
+{
+	return NULL;
+}
+
+
+struct lang_map_entry {
+	const char *name;
+	const char *string_code;
+	uint16_t usb_code;
+};
+
+#define LANG(name,code,usb_code) { name, code, usb_code }
+static struct lang_map_entry lang_map[] = {
+	LANG("Afrikaans", "af", 0x0436),
+	LANG("Albanian", "sq", 0x041C),
+	LANG("Arabic - United Arab Emirates", "ar_ae", 0x3801),
+	LANG("Arabic - Bahrain", "ar_bh", 0x3C01),
+	LANG("Arabic - Algeria", "ar_dz", 0x1401),
+	LANG("Arabic - Egypt", "ar_eg", 0x0C01),
+	LANG("Arabic - Iraq", "ar_iq", 0x0801),
+	LANG("Arabic - Jordan", "ar_jo", 0x2C01),
+	LANG("Arabic - Kuwait", "ar_kw", 0x3401),
+	LANG("Arabic - Lebanon", "ar_lb", 0x3001),
+	LANG("Arabic - Libya", "ar_ly", 0x1001),
+	LANG("Arabic - Morocco", "ar_ma", 0x1801),
+	LANG("Arabic - Oman", "ar_om", 0x2001),
+	LANG("Arabic - Qatar", "ar_qa", 0x4001),
+	LANG("Arabic - Saudi Arabia", "ar_sa", 0x0401),
+	LANG("Arabic - Syria", "ar_sy", 0x2801),
+	LANG("Arabic - Tunisia", "ar_tn", 0x1C01),
+	LANG("Arabic - Yemen", "ar_ye", 0x2401),
+	LANG("Armenian", "hy", 0x042B),
+	LANG("Azeri - Latin", "az_az", 0x042C),
+	LANG("Azeri - Cyrillic", "az_az", 0x082C),
+	LANG("Basque", "eu", 0x042D),
+	LANG("Belarusian", "be", 0x0423),
+	LANG("Bulgarian", "bg", 0x0402),
+	LANG("Catalan", "ca", 0x0403),
+	LANG("Chinese - China", "zh_cn", 0x0804),
+	LANG("Chinese - Hong Kong SAR", "zh_hk", 0x0C04),
+	LANG("Chinese - Macau SAR", "zh_mo", 0x1404),
+	LANG("Chinese - Singapore", "zh_sg", 0x1004),
+	LANG("Chinese - Taiwan", "zh_tw", 0x0404),
+	LANG("Croatian", "hr", 0x041A),
+	LANG("Czech", "cs", 0x0405),
+	LANG("Danish", "da", 0x0406),
+	LANG("Dutch - Netherlands", "nl_nl", 0x0413),
+	LANG("Dutch - Belgium", "nl_be", 0x0813),
+	LANG("English - Australia", "en_au", 0x0C09),
+	LANG("English - Belize", "en_bz", 0x2809),
+	LANG("English - Canada", "en_ca", 0x1009),
+	LANG("English - Caribbean", "en_cb", 0x2409),
+	LANG("English - Ireland", "en_ie", 0x1809),
+	LANG("English - Jamaica", "en_jm", 0x2009),
+	LANG("English - New Zealand", "en_nz", 0x1409),
+	LANG("English - Phillippines", "en_ph", 0x3409),
+	LANG("English - Southern Africa", "en_za", 0x1C09),
+	LANG("English - Trinidad", "en_tt", 0x2C09),
+	LANG("English - Great Britain", "en_gb", 0x0809),
+	LANG("English - United States", "en_us", 0x0409),
+	LANG("Estonian", "et", 0x0425),
+	LANG("Farsi", "fa", 0x0429),
+	LANG("Finnish", "fi", 0x040B),
+	LANG("Faroese", "fo", 0x0438),
+	LANG("French - France", "fr_fr", 0x040C),
+	LANG("French - Belgium", "fr_be", 0x080C),
+	LANG("French - Canada", "fr_ca", 0x0C0C),
+	LANG("French - Luxembourg", "fr_lu", 0x140C),
+	LANG("French - Switzerland", "fr_ch", 0x100C),
+	LANG("Gaelic - Ireland", "gd_ie", 0x083C),
+	LANG("Gaelic - Scotland", "gd", 0x043C),
+	LANG("German - Germany", "de_de", 0x0407),
+	LANG("German - Austria", "de_at", 0x0C07),
+	LANG("German - Liechtenstein", "de_li", 0x1407),
+	LANG("German - Luxembourg", "de_lu", 0x1007),
+	LANG("German - Switzerland", "de_ch", 0x0807),
+	LANG("Greek", "el", 0x0408),
+	LANG("Hebrew", "he", 0x040D),
+	LANG("Hindi", "hi", 0x0439),
+	LANG("Hungarian", "hu", 0x040E),
+	LANG("Icelandic", "is", 0x040F),
+	LANG("Indonesian", "id", 0x0421),
+	LANG("Italian - Italy", "it_it", 0x0410),
+	LANG("Italian - Switzerland", "it_ch", 0x0810),
+	LANG("Japanese", "ja", 0x0411),
+	LANG("Korean", "ko", 0x0412),
+	LANG("Latvian", "lv", 0x0426),
+	LANG("Lithuanian", "lt", 0x0427),
+	LANG("F.Y.R.O. Macedonia", "mk", 0x042F),
+	LANG("Malay - Malaysia", "ms_my", 0x043E),
+	LANG("Malay – Brunei", "ms_bn", 0x083E),
+	LANG("Maltese", "mt", 0x043A),
+	LANG("Marathi", "mr", 0x044E),
+	LANG("Norwegian - Bokml", "no_no", 0x0414),
+	LANG("Norwegian - Nynorsk", "no_no", 0x0814),
+	LANG("Polish", "pl", 0x0415),
+	LANG("Portuguese - Portugal", "pt_pt", 0x0816),
+	LANG("Portuguese - Brazil", "pt_br", 0x0416),
+	LANG("Raeto-Romance", "rm", 0x0417),
+	LANG("Romanian - Romania", "ro", 0x0418),
+	LANG("Romanian - Republic of Moldova", "ro_mo", 0x0818),
+	LANG("Russian", "ru", 0x0419),
+	LANG("Russian - Republic of Moldova", "ru_mo", 0x0819),
+	LANG("Sanskrit", "sa", 0x044F),
+	LANG("Serbian - Cyrillic", "sr_sp", 0x0C1A),
+	LANG("Serbian - Latin", "sr_sp", 0x081A),
+	LANG("Setsuana", "tn", 0x0432),
+	LANG("Slovenian", "sl", 0x0424),
+	LANG("Slovak", "sk", 0x041B),
+	LANG("Sorbian", "sb", 0x042E),
+	LANG("Spanish - Spain (Traditional)", "es_es", 0x040A),
+	LANG("Spanish - Argentina", "es_ar", 0x2C0A),
+	LANG("Spanish - Bolivia", "es_bo", 0x400A),
+	LANG("Spanish - Chile", "es_cl", 0x340A),
+	LANG("Spanish - Colombia", "es_co", 0x240A),
+	LANG("Spanish - Costa Rica", "es_cr", 0x140A),
+	LANG("Spanish - Dominican Republic", "es_do", 0x1C0A),
+	LANG("Spanish - Ecuador", "es_ec", 0x300A),
+	LANG("Spanish - Guatemala", "es_gt", 0x100A),
+	LANG("Spanish - Honduras", "es_hn", 0x480A),
+	LANG("Spanish - Mexico", "es_mx", 0x080A),
+	LANG("Spanish - Nicaragua", "es_ni", 0x4C0A),
+	LANG("Spanish - Panama", "es_pa", 0x180A),
+	LANG("Spanish - Peru", "es_pe", 0x280A),
+	LANG("Spanish - Puerto Rico", "es_pr", 0x500A),
+	LANG("Spanish - Paraguay", "es_py", 0x3C0A),
+	LANG("Spanish - El Salvador", "es_sv", 0x440A),
+	LANG("Spanish - Uruguay", "es_uy", 0x380A),
+	LANG("Spanish - Venezuela", "es_ve", 0x200A),
+	LANG("Southern Sotho", "st", 0x0430),
+	LANG("Swahili", "sw", 0x0441),
+	LANG("Swedish - Sweden", "sv_se", 0x041D),
+	LANG("Swedish - Finland", "sv_fi", 0x081D),
+	LANG("Tamil", "ta", 0x0449),
+	LANG("Tatar", "tt", 0X0444),
+	LANG("Thai", "th", 0x041E),
+	LANG("Turkish", "tr", 0x041F),
+	LANG("Tsonga", "ts", 0x0431),
+	LANG("Ukrainian", "uk", 0x0422),
+	LANG("Urdu", "ur", 0x0420),
+	LANG("Uzbek - Cyrillic", "uz_uz", 0x0843),
+	LANG("Uzbek – Latin", "uz_uz", 0x0443),
+	LANG("Vietnamese", "vi", 0x042A),
+	LANG("Xhosa", "xh", 0x0434),
+	LANG("Yiddish", "yi", 0x043D),
+	LANG("Zulu", "zu", 0x0435),
+	LANG(NULL, NULL, 0x0),
+};
+
+uint16_t get_usb_code_for_current_locale(void)
+{
+	char *locale;
+	char search_string[64];
+	char *ptr;
+	struct lang_map_entry *lang;
+
+	/* Get the current locale. */
+	locale = setlocale(0, NULL);
+	if (!locale)
+		return 0x0;
+
+	/* Make a copy of the current locale string. */
+	strncpy(search_string, locale, sizeof(search_string));
+	search_string[sizeof(search_string)-1] = '\0';
+
+	/* Chop off the encoding part, and make it lower case. */
+	ptr = search_string;
+	while (*ptr) {
+		*ptr = tolower(*ptr);
+		if (*ptr == '.') {
+			*ptr = '\0';
+			break;
+		}
+		ptr++;
+	}
+
+	/* Find the entry which matches the string code of our locale. */
+	lang = lang_map;
+	while (lang->string_code) {
+		if (!strcmp(lang->string_code, search_string)) {
+			return lang->usb_code;
+		}
+		lang++;
+	}
+
+	/* There was no match. Find with just the language only. */
+	/* Chop off the variant. Chop it off at the '_'. */
+	ptr = search_string;
+	while (*ptr) {
+		*ptr = tolower(*ptr);
+		if (*ptr == '_') {
+			*ptr = '\0';
+			break;
+		}
+		ptr++;
+	}
+
+#if 0 /* TODO: Do we need this? */
+	/* Find the entry which matches the string code of our language. */
+	lang = lang_map;
+	while (lang->string_code) {
+		if (!strcmp(lang->string_code, search_string)) {
+			return lang->usb_code;
+		}
+		lang++;
+	}
+#endif
+
+	/* Found nothing. */
+	return 0x0;
+}
+
+#ifdef __cplusplus
+}
+#endif

--- a/hid_windows.c
+++ b/hid_windows.c
@@ -1,0 +1,923 @@
+/*******************************************************
+ HIDAPI - Multi-Platform library for
+ communication with HID devices.
+
+ Alan Ott
+ Signal 11 Software
+
+ 8/22/2009
+
+ Copyright 2009, All Rights Reserved.
+ 
+ At the discretion of the user of this library,
+ this software may be licensed under the terms of the
+ GNU General Public License v3, a BSD-Style license, or the
+ original HIDAPI license as outlined in the LICENSE.txt,
+ LICENSE-gpl3.txt, LICENSE-bsd.txt, and LICENSE-orig.txt
+ files located at the root of the source distribution.
+ These files may also be found in the public source
+ code repository located at:
+        http://github.com/signal11/hidapi .
+********************************************************/
+
+#include <windows.h>
+
+#ifndef _NTDEF_
+typedef LONG NTSTATUS;
+#endif
+
+#ifdef __MINGW32__
+#include <ntdef.h>
+#include <winbase.h>
+#endif
+
+#ifdef __CYGWIN__
+#include <ntdef.h>
+#define _wcsdup wcsdup
+#endif
+
+/*#define HIDAPI_USE_DDK*/
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+	#include <setupapi.h>
+	#include <winioctl.h>
+	#ifdef HIDAPI_USE_DDK
+		#include <hidsdi.h>
+	#endif
+
+	/* Copied from inc/ddk/hidclass.h, part of the Windows DDK. */
+	#define HID_OUT_CTL_CODE(id)  \
+		CTL_CODE(FILE_DEVICE_KEYBOARD, (id), METHOD_OUT_DIRECT, FILE_ANY_ACCESS)
+	#define IOCTL_HID_GET_FEATURE                   HID_OUT_CTL_CODE(100)
+
+#ifdef __cplusplus
+} /* extern "C" */
+#endif
+
+#include <stdio.h>
+#include <stdlib.h>
+
+
+#include "hidapi.h"
+
+#ifdef _MSC_VER
+	/* Thanks Microsoft, but I know how to use strncpy(). */
+	#pragma warning(disable:4996)
+#endif
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#ifndef HIDAPI_USE_DDK
+	/* Since we're not building with the DDK, and the HID header
+	   files aren't part of the SDK, we have to define all this
+	   stuff here. In lookup_functions(), the function pointers
+	   defined below are set. */
+	typedef struct _HIDD_ATTRIBUTES{
+		ULONG Size;
+		USHORT VendorID;
+		USHORT ProductID;
+		USHORT VersionNumber;
+	} HIDD_ATTRIBUTES, *PHIDD_ATTRIBUTES;
+
+	typedef USHORT USAGE;
+	typedef struct _HIDP_CAPS {
+		USAGE Usage;
+		USAGE UsagePage;
+		USHORT InputReportByteLength;
+		USHORT OutputReportByteLength;
+		USHORT FeatureReportByteLength;
+		USHORT Reserved[17];
+		USHORT fields_not_used_by_hidapi[10];
+	} HIDP_CAPS, *PHIDP_CAPS;
+	typedef void* PHIDP_PREPARSED_DATA;
+	#define HIDP_STATUS_SUCCESS 0x110000
+
+	typedef BOOLEAN (__stdcall *HidD_GetAttributes_)(HANDLE device, PHIDD_ATTRIBUTES attrib);
+	typedef BOOLEAN (__stdcall *HidD_GetSerialNumberString_)(HANDLE device, PVOID buffer, ULONG buffer_len);
+	typedef BOOLEAN (__stdcall *HidD_GetManufacturerString_)(HANDLE handle, PVOID buffer, ULONG buffer_len);
+	typedef BOOLEAN (__stdcall *HidD_GetProductString_)(HANDLE handle, PVOID buffer, ULONG buffer_len);
+	typedef BOOLEAN (__stdcall *HidD_SetFeature_)(HANDLE handle, PVOID data, ULONG length);
+	typedef BOOLEAN (__stdcall *HidD_GetFeature_)(HANDLE handle, PVOID data, ULONG length);
+	typedef BOOLEAN (__stdcall *HidD_GetIndexedString_)(HANDLE handle, ULONG string_index, PVOID buffer, ULONG buffer_len);
+	typedef BOOLEAN (__stdcall *HidD_GetPreparsedData_)(HANDLE handle, PHIDP_PREPARSED_DATA *preparsed_data);
+	typedef BOOLEAN (__stdcall *HidD_FreePreparsedData_)(PHIDP_PREPARSED_DATA preparsed_data);
+	typedef NTSTATUS (__stdcall *HidP_GetCaps_)(PHIDP_PREPARSED_DATA preparsed_data, HIDP_CAPS *caps);
+
+	static HidD_GetAttributes_ HidD_GetAttributes;
+	static HidD_GetSerialNumberString_ HidD_GetSerialNumberString;
+	static HidD_GetManufacturerString_ HidD_GetManufacturerString;
+	static HidD_GetProductString_ HidD_GetProductString;
+	static HidD_SetFeature_ HidD_SetFeature;
+	static HidD_GetFeature_ HidD_GetFeature;
+	static HidD_GetIndexedString_ HidD_GetIndexedString;
+	static HidD_GetPreparsedData_ HidD_GetPreparsedData;
+	static HidD_FreePreparsedData_ HidD_FreePreparsedData;
+	static HidP_GetCaps_ HidP_GetCaps;
+
+	static HMODULE lib_handle = NULL;
+	static BOOLEAN initialized = FALSE;
+#endif /* HIDAPI_USE_DDK */
+
+struct hid_device_ {
+		HANDLE device_handle;
+		BOOL blocking;
+		USHORT output_report_length;
+		size_t input_report_length;
+		void *last_error_str;
+		DWORD last_error_num;
+		BOOL read_pending;
+		char *read_buf;
+		OVERLAPPED ol;
+};
+
+static hid_device *new_hid_device()
+{
+	hid_device *dev = (hid_device*) calloc(1, sizeof(hid_device));
+	dev->device_handle = INVALID_HANDLE_VALUE;
+	dev->blocking = TRUE;
+	dev->output_report_length = 0;
+	dev->input_report_length = 0;
+	dev->last_error_str = NULL;
+	dev->last_error_num = 0;
+	dev->read_pending = FALSE;
+	dev->read_buf = NULL;
+	memset(&dev->ol, 0, sizeof(dev->ol));
+	dev->ol.hEvent = CreateEvent(NULL, FALSE, FALSE /*inital state f=nonsignaled*/, NULL);
+
+	return dev;
+}
+
+static void free_hid_device(hid_device *dev)
+{
+	CloseHandle(dev->ol.hEvent);
+	CloseHandle(dev->device_handle);
+	LocalFree(dev->last_error_str);
+	free(dev->read_buf);
+	free(dev);
+}
+
+static void register_error(hid_device *device, const char *op)
+{
+	WCHAR *ptr, *msg;
+
+	FormatMessageW(FORMAT_MESSAGE_ALLOCATE_BUFFER |
+		FORMAT_MESSAGE_FROM_SYSTEM |
+		FORMAT_MESSAGE_IGNORE_INSERTS,
+		NULL,
+		GetLastError(),
+		MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT),
+		(LPVOID)&msg, 0/*sz*/,
+		NULL);
+	
+	/* Get rid of the CR and LF that FormatMessage() sticks at the
+	   end of the message. Thanks Microsoft! */
+	ptr = msg;
+	while (*ptr) {
+		if (*ptr == '\r') {
+			*ptr = 0x0000;
+			break;
+		}
+		ptr++;
+	}
+
+	/* Store the message off in the Device entry so that
+	   the hid_error() function can pick it up. */
+	LocalFree(device->last_error_str);
+	device->last_error_str = msg;
+}
+
+#ifndef HIDAPI_USE_DDK
+static int lookup_functions()
+{
+	lib_handle = LoadLibraryA("hid.dll");
+	if (lib_handle) {
+#define RESOLVE(x) x = (x##_)GetProcAddress(lib_handle, #x); if (!x) return -1;
+		RESOLVE(HidD_GetAttributes);
+		RESOLVE(HidD_GetSerialNumberString);
+		RESOLVE(HidD_GetManufacturerString);
+		RESOLVE(HidD_GetProductString);
+		RESOLVE(HidD_SetFeature);
+		RESOLVE(HidD_GetFeature);
+		RESOLVE(HidD_GetIndexedString);
+		RESOLVE(HidD_GetPreparsedData);
+		RESOLVE(HidD_FreePreparsedData);
+		RESOLVE(HidP_GetCaps);
+#undef RESOLVE
+	}
+	else
+		return -1;
+
+	return 0;
+}
+#endif
+
+static HANDLE open_device(const char *path, BOOL enumerate)
+{
+	HANDLE handle;
+	DWORD desired_access = (enumerate)? 0: (GENERIC_WRITE | GENERIC_READ);
+	DWORD share_mode = (enumerate)?
+	                      FILE_SHARE_READ|FILE_SHARE_WRITE:
+	                      FILE_SHARE_READ;
+
+	handle = CreateFileA(path,
+		desired_access,
+		share_mode,
+		NULL,
+		OPEN_EXISTING,
+		FILE_FLAG_OVERLAPPED,/*FILE_ATTRIBUTE_NORMAL,*/
+		0);
+
+	return handle;
+}
+
+int HID_API_EXPORT hid_init(void)
+{
+#ifndef HIDAPI_USE_DDK
+	if (!initialized) {
+		if (lookup_functions() < 0) {
+			hid_exit();
+			return -1;
+		}
+		initialized = TRUE;
+	}
+#endif
+	return 0;
+}
+
+int HID_API_EXPORT hid_exit(void)
+{
+#ifndef HIDAPI_USE_DDK
+	if (lib_handle)
+		FreeLibrary(lib_handle);
+	lib_handle = NULL;
+	initialized = FALSE;
+#endif
+	return 0;
+}
+
+struct hid_device_info HID_API_EXPORT * HID_API_CALL hid_enumerate(unsigned short vendor_id, unsigned short product_id)
+{
+	BOOL res;
+	struct hid_device_info *root = NULL; /* return object */
+	struct hid_device_info *cur_dev = NULL;
+
+	/* Windows objects for interacting with the driver. */
+	GUID InterfaceClassGuid = {0x4d1e55b2, 0xf16f, 0x11cf, {0x88, 0xcb, 0x00, 0x11, 0x11, 0x00, 0x00, 0x30} };
+	SP_DEVINFO_DATA devinfo_data;
+	SP_DEVICE_INTERFACE_DATA device_interface_data;
+	SP_DEVICE_INTERFACE_DETAIL_DATA_A *device_interface_detail_data = NULL;
+	HDEVINFO device_info_set = INVALID_HANDLE_VALUE;
+	int device_index = 0;
+	int i;
+
+	if (hid_init() < 0)
+		return NULL;
+
+	/* Initialize the Windows objects. */
+	memset(&devinfo_data, 0x0, sizeof(devinfo_data));
+	devinfo_data.cbSize = sizeof(SP_DEVINFO_DATA);
+	device_interface_data.cbSize = sizeof(SP_DEVICE_INTERFACE_DATA);
+
+	/* Get information for all the devices belonging to the HID class. */
+	device_info_set = SetupDiGetClassDevsA(&InterfaceClassGuid, NULL, NULL, DIGCF_PRESENT | DIGCF_DEVICEINTERFACE);
+	
+	/* Iterate over each device in the HID class, looking for the right one. */
+	
+	for (;;) {
+		HANDLE write_handle = INVALID_HANDLE_VALUE;
+		DWORD required_size = 0;
+		HIDD_ATTRIBUTES attrib;
+
+		res = SetupDiEnumDeviceInterfaces(device_info_set,
+			NULL,
+			&InterfaceClassGuid,
+			device_index,
+			&device_interface_data);
+		
+		if (!res) {
+			/* A return of FALSE from this function means that
+			   there are no more devices. */
+			break;
+		}
+
+		/* Call with 0-sized detail size, and let the function
+		   tell us how long the detail struct needs to be. The
+		   size is put in &required_size. */
+		res = SetupDiGetDeviceInterfaceDetailA(device_info_set,
+			&device_interface_data,
+			NULL,
+			0,
+			&required_size,
+			NULL);
+
+		/* Allocate a long enough structure for device_interface_detail_data. */
+		device_interface_detail_data = (SP_DEVICE_INTERFACE_DETAIL_DATA_A*) malloc(required_size);
+		device_interface_detail_data->cbSize = sizeof(SP_DEVICE_INTERFACE_DETAIL_DATA_A);
+
+		/* Get the detailed data for this device. The detail data gives us
+		   the device path for this device, which is then passed into
+		   CreateFile() to get a handle to the device. */
+		res = SetupDiGetDeviceInterfaceDetailA(device_info_set,
+			&device_interface_data,
+			device_interface_detail_data,
+			required_size,
+			NULL,
+			NULL);
+
+		if (!res) {
+			/* register_error(dev, "Unable to call SetupDiGetDeviceInterfaceDetail");
+			   Continue to the next device. */
+			goto cont;
+		}
+
+		/* Make sure this device is of Setup Class "HIDClass" and has a
+		   driver bound to it. */
+		for (i = 0; ; i++) {
+			char driver_name[256];
+
+			/* Populate devinfo_data. This function will return failure
+			   when there are no more interfaces left. */
+			res = SetupDiEnumDeviceInfo(device_info_set, i, &devinfo_data);
+			if (!res)
+				goto cont;
+
+			res = SetupDiGetDeviceRegistryPropertyA(device_info_set, &devinfo_data,
+			               SPDRP_CLASS, NULL, (PBYTE)driver_name, sizeof(driver_name), NULL);
+			if (!res)
+				goto cont;
+
+			if (strcmp(driver_name, "HIDClass") == 0) {
+				/* See if there's a driver bound. */
+				res = SetupDiGetDeviceRegistryPropertyA(device_info_set, &devinfo_data,
+				           SPDRP_DRIVER, NULL, (PBYTE)driver_name, sizeof(driver_name), NULL);
+				if (res)
+					break;
+			}
+		}
+
+		//wprintf(L"HandleName: %s\n", device_interface_detail_data->DevicePath);
+
+		/* Open a handle to the device */
+		write_handle = open_device(device_interface_detail_data->DevicePath, TRUE);
+
+		/* Check validity of write_handle. */
+		if (write_handle == INVALID_HANDLE_VALUE) {
+			/* Unable to open the device. */
+			//register_error(dev, "CreateFile");
+			goto cont_close;
+		}		
+
+
+		/* Get the Vendor ID and Product ID for this device. */
+		attrib.Size = sizeof(HIDD_ATTRIBUTES);
+		HidD_GetAttributes(write_handle, &attrib);
+		//wprintf(L"Product/Vendor: %x %x\n", attrib.ProductID, attrib.VendorID);
+
+		/* Check the VID/PID to see if we should add this
+		   device to the enumeration list. */
+		if ((vendor_id == 0x0 || attrib.VendorID == vendor_id) &&
+		    (product_id == 0x0 || attrib.ProductID == product_id)) {
+
+			#define WSTR_LEN 512
+			const char *str;
+			struct hid_device_info *tmp;
+			PHIDP_PREPARSED_DATA pp_data = NULL;
+			HIDP_CAPS caps;
+			BOOLEAN res;
+			NTSTATUS nt_res;
+			wchar_t wstr[WSTR_LEN]; /* TODO: Determine Size */
+			size_t len;
+
+			/* VID/PID match. Create the record. */
+			tmp = (struct hid_device_info*) calloc(1, sizeof(struct hid_device_info));
+			if (cur_dev) {
+				cur_dev->next = tmp;
+			}
+			else {
+				root = tmp;
+			}
+			cur_dev = tmp;
+
+			/* Get the Usage Page and Usage for this device. */
+			res = HidD_GetPreparsedData(write_handle, &pp_data);
+			if (res) {
+				nt_res = HidP_GetCaps(pp_data, &caps);
+				if (nt_res == HIDP_STATUS_SUCCESS) {
+					cur_dev->usage_page = caps.UsagePage;
+					cur_dev->usage = caps.Usage;
+				}
+
+				HidD_FreePreparsedData(pp_data);
+			}
+			
+			/* Fill out the record */
+			cur_dev->next = NULL;
+			str = device_interface_detail_data->DevicePath;
+			if (str) {
+				len = strlen(str);
+				cur_dev->path = (char*) calloc(len+1, sizeof(char));
+				strncpy(cur_dev->path, str, len+1);
+				cur_dev->path[len] = '\0';
+			}
+			else
+				cur_dev->path = NULL;
+
+			/* Serial Number */
+			res = HidD_GetSerialNumberString(write_handle, wstr, sizeof(wstr));
+			wstr[WSTR_LEN-1] = 0x0000;
+			if (res) {
+				cur_dev->serial_number = _wcsdup(wstr);
+			}
+
+			/* Manufacturer String */
+			res = HidD_GetManufacturerString(write_handle, wstr, sizeof(wstr));
+			wstr[WSTR_LEN-1] = 0x0000;
+			if (res) {
+				cur_dev->manufacturer_string = _wcsdup(wstr);
+			}
+
+			/* Product String */
+			res = HidD_GetProductString(write_handle, wstr, sizeof(wstr));
+			wstr[WSTR_LEN-1] = 0x0000;
+			if (res) {
+				cur_dev->product_string = _wcsdup(wstr);
+			}
+
+			/* VID/PID */
+			cur_dev->vendor_id = attrib.VendorID;
+			cur_dev->product_id = attrib.ProductID;
+
+			/* Release Number */
+			cur_dev->release_number = attrib.VersionNumber;
+
+			/* Interface Number. It can sometimes be parsed out of the path
+			   on Windows if a device has multiple interfaces. See
+			   http://msdn.microsoft.com/en-us/windows/hardware/gg487473 or
+			   search for "Hardware IDs for HID Devices" at MSDN. If it's not
+			   in the path, it's set to -1. */
+			cur_dev->interface_number = -1;
+			if (cur_dev->path) {
+				char *interface_component = strstr(cur_dev->path, "&mi_");
+				if (interface_component) {
+					char *hex_str = interface_component + 4;
+					char *endptr = NULL;
+					cur_dev->interface_number = strtol(hex_str, &endptr, 16);
+					if (endptr == hex_str) {
+						/* The parsing failed. Set interface_number to -1. */
+						cur_dev->interface_number = -1;
+					}
+				}
+			}
+		}
+
+cont_close:
+		CloseHandle(write_handle);
+cont:
+		/* We no longer need the detail data. It can be freed */
+		free(device_interface_detail_data);
+
+		device_index++;
+
+	}
+
+	/* Close the device information handle. */
+	SetupDiDestroyDeviceInfoList(device_info_set);
+
+	return root;
+
+}
+
+void  HID_API_EXPORT HID_API_CALL hid_free_enumeration(struct hid_device_info *devs)
+{
+	/* TODO: Merge this with the Linux version. This function is platform-independent. */
+	struct hid_device_info *d = devs;
+	while (d) {
+		struct hid_device_info *next = d->next;
+		free(d->path);
+		free(d->serial_number);
+		free(d->manufacturer_string);
+		free(d->product_string);
+		free(d);
+		d = next;
+	}
+}
+
+
+HID_API_EXPORT hid_device * HID_API_CALL hid_open(unsigned short vendor_id, unsigned short product_id, const wchar_t *serial_number)
+{
+	/* TODO: Merge this functions with the Linux version. This function should be platform independent. */
+	struct hid_device_info *devs, *cur_dev;
+	const char *path_to_open = NULL;
+	hid_device *handle = NULL;
+	
+	devs = hid_enumerate(vendor_id, product_id);
+	cur_dev = devs;
+	while (cur_dev) {
+		if (cur_dev->vendor_id == vendor_id &&
+		    cur_dev->product_id == product_id) {
+			if (serial_number) {
+				if (wcscmp(serial_number, cur_dev->serial_number) == 0) {
+					path_to_open = cur_dev->path;
+					break;
+				}
+			}
+			else {
+				path_to_open = cur_dev->path;
+				break;
+			}
+		}
+		cur_dev = cur_dev->next;
+	}
+
+	if (path_to_open) {
+		/* Open the device */
+		handle = hid_open_path(path_to_open);
+	}
+
+	hid_free_enumeration(devs);
+	
+	return handle;
+}
+
+HID_API_EXPORT hid_device * HID_API_CALL hid_open_path(const char *path)
+{
+	hid_device *dev;
+	HIDP_CAPS caps;
+	PHIDP_PREPARSED_DATA pp_data = NULL;
+	BOOLEAN res;
+	NTSTATUS nt_res;
+
+	if (hid_init() < 0) {
+		return NULL;
+	}
+
+	dev = new_hid_device();
+
+	/* Open a handle to the device */
+	dev->device_handle = open_device(path, FALSE);
+
+	/* Check validity of write_handle. */
+	if (dev->device_handle == INVALID_HANDLE_VALUE) {
+		/* Unable to open the device. */
+		register_error(dev, "CreateFile");
+		goto err;
+	}
+
+	/* Get the Input Report length for the device. */
+	res = HidD_GetPreparsedData(dev->device_handle, &pp_data);
+	if (!res) {
+		register_error(dev, "HidD_GetPreparsedData");
+		goto err;
+	}
+	nt_res = HidP_GetCaps(pp_data, &caps);
+	if (nt_res != HIDP_STATUS_SUCCESS) {
+		register_error(dev, "HidP_GetCaps");	
+		goto err_pp_data;
+	}
+	dev->output_report_length = caps.OutputReportByteLength;
+	dev->input_report_length = caps.InputReportByteLength;
+	HidD_FreePreparsedData(pp_data);
+
+	dev->read_buf = (char*) malloc(dev->input_report_length);
+
+	return dev;
+
+err_pp_data:
+		HidD_FreePreparsedData(pp_data);
+err:	
+		free_hid_device(dev);
+		return NULL;
+}
+
+int HID_API_EXPORT HID_API_CALL hid_write(hid_device *dev, const unsigned char *data, size_t length)
+{
+	DWORD bytes_written;
+	BOOL res;
+
+	OVERLAPPED ol;
+	unsigned char *buf;
+	memset(&ol, 0, sizeof(ol));
+
+	/* Make sure the right number of bytes are passed to WriteFile. Windows
+	   expects the number of bytes which are in the _longest_ report (plus
+	   one for the report number) bytes even if the data is a report
+	   which is shorter than that. Windows gives us this value in
+	   caps.OutputReportByteLength. If a user passes in fewer bytes than this,
+	   create a temporary buffer which is the proper size. */
+	if (length >= dev->output_report_length) {
+		/* The user passed the right number of bytes. Use the buffer as-is. */
+		buf = (unsigned char *) data;
+	} else {
+		/* Create a temporary buffer and copy the user's data
+		   into it, padding the rest with zeros. */
+		buf = (unsigned char *) malloc(dev->output_report_length);
+		memcpy(buf, data, length);
+		memset(buf + length, 0, dev->output_report_length - length);
+		length = dev->output_report_length;
+	}
+
+	res = WriteFile(dev->device_handle, buf, length, NULL, &ol);
+	
+	if (!res) {
+		if (GetLastError() != ERROR_IO_PENDING) {
+			/* WriteFile() failed. Return error. */
+			register_error(dev, "WriteFile");
+			bytes_written = -1;
+			goto end_of_function;
+		}
+	}
+
+	/* Wait here until the write is done. This makes
+	   hid_write() synchronous. */
+	res = GetOverlappedResult(dev->device_handle, &ol, &bytes_written, TRUE/*wait*/);
+	if (!res) {
+		/* The Write operation failed. */
+		register_error(dev, "WriteFile");
+		bytes_written = -1;
+		goto end_of_function;
+	}
+
+end_of_function:
+	if (buf != data)
+		free(buf);
+
+	return bytes_written;
+}
+
+
+int HID_API_EXPORT HID_API_CALL hid_read_timeout(hid_device *dev, unsigned char *data, size_t length, int milliseconds)
+{
+	DWORD bytes_read = 0;
+	BOOL res;
+
+	/* Copy the handle for convenience. */
+	HANDLE ev = dev->ol.hEvent;
+
+	if (!dev->read_pending) {
+		/* Start an Overlapped I/O read. */
+		dev->read_pending = TRUE;
+		memset(dev->read_buf, 0, dev->input_report_length);
+		ResetEvent(ev);
+		res = ReadFile(dev->device_handle, dev->read_buf, dev->input_report_length, &bytes_read, &dev->ol);
+		
+		if (!res) {
+			if (GetLastError() != ERROR_IO_PENDING) {
+				/* ReadFile() has failed.
+				   Clean up and return error. */
+				CancelIo(dev->device_handle);
+				dev->read_pending = FALSE;
+				goto end_of_function;
+			}
+		}
+	}
+
+	if (milliseconds >= 0) {
+		/* See if there is any data yet. */
+		res = WaitForSingleObject(ev, milliseconds);
+		if (res != WAIT_OBJECT_0) {
+			/* There was no data this time. Return zero bytes available,
+			   but leave the Overlapped I/O running. */
+			return 0;
+		}
+	}
+
+	/* Either WaitForSingleObject() told us that ReadFile has completed, or
+	   we are in non-blocking mode. Get the number of bytes read. The actual
+	   data has been copied to the data[] array which was passed to ReadFile(). */
+	res = GetOverlappedResult(dev->device_handle, &dev->ol, &bytes_read, TRUE/*wait*/);
+	
+	/* Set pending back to false, even if GetOverlappedResult() returned error. */
+	dev->read_pending = FALSE;
+
+	if (res && bytes_read > 0) {
+		if (dev->read_buf[0] == 0x0) {
+			/* If report numbers aren't being used, but Windows sticks a report
+			   number (0x0) on the beginning of the report anyway. To make this
+			   work like the other platforms, and to make it work more like the
+			   HID spec, we'll skip over this byte. */
+			size_t copy_len;
+			bytes_read--;
+			copy_len = length > bytes_read ? bytes_read : length;
+			memcpy(data, dev->read_buf+1, copy_len);
+		}
+		else {
+			/* Copy the whole buffer, report number and all. */
+			size_t copy_len = length > bytes_read ? bytes_read : length;
+			memcpy(data, dev->read_buf, copy_len);
+		}
+	}
+	
+end_of_function:
+	if (!res) {
+		register_error(dev, "GetOverlappedResult");
+		return -1;
+	}
+	
+	return bytes_read;
+}
+
+int HID_API_EXPORT HID_API_CALL hid_read(hid_device *dev, unsigned char *data, size_t length)
+{
+	return hid_read_timeout(dev, data, length, (dev->blocking)? -1: 0);
+}
+
+int HID_API_EXPORT HID_API_CALL hid_set_nonblocking(hid_device *dev, int nonblock)
+{
+	dev->blocking = !nonblock;
+	return 0; /* Success */
+}
+
+int HID_API_EXPORT HID_API_CALL hid_send_feature_report(hid_device *dev, const unsigned char *data, size_t length)
+{
+	BOOL res = HidD_SetFeature(dev->device_handle, (PVOID)data, length);
+	if (!res) {
+		register_error(dev, "HidD_SetFeature");
+		return -1;
+	}
+
+	return length;
+}
+
+
+int HID_API_EXPORT HID_API_CALL hid_get_feature_report(hid_device *dev, unsigned char *data, size_t length)
+{
+	BOOL res;
+#if 0
+	res = HidD_GetFeature(dev->device_handle, data, length);
+	if (!res) {
+		register_error(dev, "HidD_GetFeature");
+		return -1;
+	}
+	return 0; /* HidD_GetFeature() doesn't give us an actual length, unfortunately */
+#else
+	DWORD bytes_returned;
+
+	OVERLAPPED ol;
+	memset(&ol, 0, sizeof(ol));
+
+	res = DeviceIoControl(dev->device_handle,
+		IOCTL_HID_GET_FEATURE,
+		data, length,
+		data, length,
+		&bytes_returned, &ol);
+
+	if (!res) {
+		if (GetLastError() != ERROR_IO_PENDING) {
+			/* DeviceIoControl() failed. Return error. */
+			register_error(dev, "Send Feature Report DeviceIoControl");
+			return -1;
+		}
+	}
+
+	/* Wait here until the write is done. This makes
+	   hid_get_feature_report() synchronous. */
+	res = GetOverlappedResult(dev->device_handle, &ol, &bytes_returned, TRUE/*wait*/);
+	if (!res) {
+		/* The operation failed. */
+		register_error(dev, "Send Feature Report GetOverLappedResult");
+		return -1;
+	}
+	return bytes_returned;
+#endif
+}
+
+void HID_API_EXPORT HID_API_CALL hid_close(hid_device *dev)
+{
+	if (!dev)
+		return;
+	CancelIo(dev->device_handle);
+	free_hid_device(dev);
+}
+
+int HID_API_EXPORT_CALL HID_API_CALL hid_get_manufacturer_string(hid_device *dev, wchar_t *string, size_t maxlen)
+{
+	BOOL res;
+
+	res = HidD_GetManufacturerString(dev->device_handle, string, sizeof(wchar_t) * maxlen);
+	if (!res) {
+		register_error(dev, "HidD_GetManufacturerString");
+		return -1;
+	}
+
+	return 0;
+}
+
+int HID_API_EXPORT_CALL HID_API_CALL hid_get_product_string(hid_device *dev, wchar_t *string, size_t maxlen)
+{
+	BOOL res;
+
+	res = HidD_GetProductString(dev->device_handle, string, sizeof(wchar_t) * maxlen);
+	if (!res) {
+		register_error(dev, "HidD_GetProductString");
+		return -1;
+	}
+
+	return 0;
+}
+
+int HID_API_EXPORT_CALL HID_API_CALL hid_get_serial_number_string(hid_device *dev, wchar_t *string, size_t maxlen)
+{
+	BOOL res;
+
+	res = HidD_GetSerialNumberString(dev->device_handle, string, sizeof(wchar_t) * maxlen);
+	if (!res) {
+		register_error(dev, "HidD_GetSerialNumberString");
+		return -1;
+	}
+
+	return 0;
+}
+
+int HID_API_EXPORT_CALL HID_API_CALL hid_get_indexed_string(hid_device *dev, int string_index, wchar_t *string, size_t maxlen)
+{
+	BOOL res;
+
+	res = HidD_GetIndexedString(dev->device_handle, string_index, string, sizeof(wchar_t) * maxlen);
+	if (!res) {
+		register_error(dev, "HidD_GetIndexedString");
+		return -1;
+	}
+
+	return 0;
+}
+
+
+HID_API_EXPORT const wchar_t * HID_API_CALL  hid_error(hid_device *dev)
+{
+	return (wchar_t*)dev->last_error_str;
+}
+
+
+/*#define PICPGM*/
+/*#define S11*/
+#define P32
+#ifdef S11 
+  unsigned short VendorID = 0xa0a0;
+	unsigned short ProductID = 0x0001;
+#endif
+
+#ifdef P32
+  unsigned short VendorID = 0x04d8;
+	unsigned short ProductID = 0x3f;
+#endif
+
+
+#ifdef PICPGM
+  unsigned short VendorID = 0x04d8;
+  unsigned short ProductID = 0x0033;
+#endif
+
+
+#if 0
+int __cdecl main(int argc, char* argv[])
+{
+	int res;
+	unsigned char buf[65];
+
+	UNREFERENCED_PARAMETER(argc);
+	UNREFERENCED_PARAMETER(argv);
+
+	/* Set up the command buffer. */
+	memset(buf,0x00,sizeof(buf));
+	buf[0] = 0;
+	buf[1] = 0x81;
+	
+
+	/* Open the device. */
+	int handle = open(VendorID, ProductID, L"12345");
+	if (handle < 0)
+		printf("unable to open device\n");
+
+
+	/* Toggle LED (cmd 0x80) */
+	buf[1] = 0x80;
+	res = write(handle, buf, 65);
+	if (res < 0)
+		printf("Unable to write()\n");
+
+	/* Request state (cmd 0x81) */
+	buf[1] = 0x81;
+	write(handle, buf, 65);
+	if (res < 0)
+		printf("Unable to write() (2)\n");
+
+	/* Read requested state */
+	read(handle, buf, 65);
+	if (res < 0)
+		printf("Unable to read()\n");
+
+	/* Print out the returned buffer. */
+	for (int i = 0; i < 4; i++)
+		printf("buf[%d]: %d\n", i, buf[i]);
+
+	return 0;
+}
+#endif
+
+#ifdef __cplusplus
+} /* extern "C" */
+#endif

--- a/hidapi.h
+++ b/hidapi.h
@@ -1,0 +1,387 @@
+/*******************************************************
+ HIDAPI - Multi-Platform library for
+ communication with HID devices.
+
+ Alan Ott
+ Signal 11 Software
+
+ 8/22/2009
+
+ Copyright 2009, All Rights Reserved.
+
+ At the discretion of the user of this library,
+ this software may be licensed under the terms of the
+ GNU General Public License v3, a BSD-Style license, or the
+ original HIDAPI license as outlined in the LICENSE.txt,
+ LICENSE-gpl3.txt, LICENSE-bsd.txt, and LICENSE-orig.txt
+ files located at the root of the source distribution.
+ These files may also be found in the public source
+ code repository located at:
+        http://github.com/signal11/hidapi .
+********************************************************/
+
+/** @file
+ * @defgroup API hidapi API
+ */
+
+#ifndef HIDAPI_H__
+#define HIDAPI_H__
+
+#include <wchar.h>
+
+#ifdef _WIN32
+      #define HID_API_EXPORT __declspec(dllexport)
+      #define HID_API_CALL
+#else
+      #define HID_API_EXPORT /**< API export macro */
+      #define HID_API_CALL /**< API call macro */
+#endif
+
+#define HID_API_EXPORT_CALL HID_API_EXPORT HID_API_CALL /**< API export and call macro*/
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+		struct hid_device_;
+		typedef struct hid_device_ hid_device; /**< opaque hidapi structure */
+
+		/** hidapi info structure */
+		struct hid_device_info {
+			/** Platform-specific device path */
+			char *path;
+			/** Device Vendor ID */
+			unsigned short vendor_id;
+			/** Device Product ID */
+			unsigned short product_id;
+			/** Serial Number */
+			wchar_t *serial_number;
+			/** Device Release Number in binary-coded decimal,
+			    also known as Device Version Number */
+			unsigned short release_number;
+			/** Manufacturer String */
+			wchar_t *manufacturer_string;
+			/** Product string */
+			wchar_t *product_string;
+			/** Usage Page for this Device/Interface
+			    (Windows/Mac only). */
+			unsigned short usage_page;
+			/** Usage for this Device/Interface
+			    (Windows/Mac only).*/
+			unsigned short usage;
+			/** The USB interface which this logical device
+			    represents. Valid on both Linux implementations
+			    in all cases, and valid on the Windows implementation
+			    only if the device contains more than one interface. */
+			int interface_number;
+
+			/** Pointer to the next device */
+			struct hid_device_info *next;
+		};
+
+
+		/** @brief Initialize the HIDAPI library.
+
+			This function initializes the HIDAPI library. Calling it is not
+			strictly necessary, as it will be called automatically by
+			hid_enumerate() and any of the hid_open_*() functions if it is
+			needed.  This function should be called at the beginning of
+			execution however, if there is a chance of HIDAPI handles
+			being opened by different threads simultaneously.
+			
+			@ingroup API
+
+			@returns
+				This function returns 0 on success and -1 on error.
+		*/
+		int HID_API_EXPORT HID_API_CALL hid_init(void);
+
+		/** @brief Finalize the HIDAPI library.
+
+			This function frees all of the static data associated with
+			HIDAPI. It should be called at the end of execution to avoid
+			memory leaks.
+
+			@ingroup API
+
+		    @returns
+				This function returns 0 on success and -1 on error.
+		*/
+		int HID_API_EXPORT HID_API_CALL hid_exit(void);
+
+		/** @brief Enumerate the HID Devices.
+
+			This function returns a linked list of all the HID devices
+			attached to the system which match vendor_id and product_id.
+			If @p vendor_id is set to 0 then any vendor matches.
+			If @p product_id is set to 0 then any product matches.
+			If @p vendor_id and @p product_id are both set to 0, then
+			all HID devices will be returned.
+
+			@ingroup API
+			@param vendor_id The Vendor ID (VID) of the types of device
+				to open.
+			@param product_id The Product ID (PID) of the types of
+				device to open.
+
+		    @returns
+		    	This function returns a pointer to a linked list of type
+		    	struct #hid_device, containing information about the HID devices
+		    	attached to the system, or NULL in the case of failure. Free
+		    	this linked list by calling hid_free_enumeration().
+		*/
+		struct hid_device_info HID_API_EXPORT * HID_API_CALL hid_enumerate(unsigned short vendor_id, unsigned short product_id);
+
+		/** @brief Free an enumeration Linked List
+
+		    This function frees a linked list created by hid_enumerate().
+
+			@ingroup API
+		    @param devs Pointer to a list of struct_device returned from
+		    	      hid_enumerate().
+		*/
+		void  HID_API_EXPORT HID_API_CALL hid_free_enumeration(struct hid_device_info *devs);
+
+		/** @brief Open a HID device using a Vendor ID (VID), Product ID
+			(PID) and optionally a serial number.
+
+			If @p serial_number is NULL, the first device with the
+			specified VID and PID is opened.
+
+			@ingroup API
+			@param vendor_id The Vendor ID (VID) of the device to open.
+			@param product_id The Product ID (PID) of the device to open.
+			@param serial_number The Serial Number of the device to open
+				               (Optionally NULL).
+
+			@returns
+				This function returns a pointer to a #hid_device object on
+				success or NULL on failure.
+		*/
+		HID_API_EXPORT hid_device * HID_API_CALL hid_open(unsigned short vendor_id, unsigned short product_id, const wchar_t *serial_number);
+
+		/** @brief Open a HID device by its path name.
+
+			The path name be determined by calling hid_enumerate(), or a
+			platform-specific path name can be used (eg: /dev/hidraw0 on
+			Linux).
+
+			@ingroup API
+		    @param path The path name of the device to open
+
+			@returns
+				This function returns a pointer to a #hid_device object on
+				success or NULL on failure.
+		*/
+		HID_API_EXPORT hid_device * HID_API_CALL hid_open_path(const char *path);
+
+		/** @brief Write an Output report to a HID device.
+
+			The first byte of @p data[] must contain the Report ID. For
+			devices which only support a single report, this must be set
+			to 0x0. The remaining bytes contain the report data. Since
+			the Report ID is mandatory, calls to hid_write() will always
+			contain one more byte than the report contains. For example,
+			if a hid report is 16 bytes long, 17 bytes must be passed to
+			hid_write(), the Report ID (or 0x0, for devices with a
+			single report), followed by the report data (16 bytes). In
+			this example, the length passed in would be 17.
+
+			hid_write() will send the data on the first OUT endpoint, if
+			one exists. If it does not, it will send the data through
+			the Control Endpoint (Endpoint 0).
+
+			@ingroup API
+			@param device A device handle returned from hid_open().
+			@param data The data to send, including the report number as
+				the first byte.
+			@param length The length in bytes of the data to send.
+
+			@returns
+				This function returns the actual number of bytes written and
+				-1 on error.
+		*/
+		int  HID_API_EXPORT HID_API_CALL hid_write(hid_device *device, const unsigned char *data, size_t length);
+
+		/** @brief Read an Input report from a HID device with timeout.
+
+			Input reports are returned
+			to the host through the INTERRUPT IN endpoint. The first byte will
+			contain the Report number if the device uses numbered reports.
+
+			@ingroup API
+			@param device A device handle returned from hid_open().
+			@param data A buffer to put the read data into.
+			@param length The number of bytes to read. For devices with
+				multiple reports, make sure to read an extra byte for
+				the report number.
+			@param milliseconds timeout in milliseconds or -1 for blocking wait.
+
+			@returns
+				This function returns the actual number of bytes read and
+				-1 on error. If no packet was available to be read within
+				the timeout period, this function returns 0.
+		*/
+		int HID_API_EXPORT HID_API_CALL hid_read_timeout(hid_device *dev, unsigned char *data, size_t length, int milliseconds);
+
+		/** @brief Read an Input report from a HID device.
+
+			Input reports are returned
+		    to the host through the INTERRUPT IN endpoint. The first byte will
+			contain the Report number if the device uses numbered reports.
+
+			@ingroup API
+			@param device A device handle returned from hid_open().
+			@param data A buffer to put the read data into.
+			@param length The number of bytes to read. For devices with
+				multiple reports, make sure to read an extra byte for
+				the report number.
+
+			@returns
+				This function returns the actual number of bytes read and
+				-1 on error. If no packet was available to be read and
+				the handle is in non-blocking mode, this function returns 0.
+		*/
+		int  HID_API_EXPORT HID_API_CALL hid_read(hid_device *device, unsigned char *data, size_t length);
+
+		/** @brief Set the device handle to be non-blocking.
+
+			In non-blocking mode calls to hid_read() will return
+			immediately with a value of 0 if there is no data to be
+			read. In blocking mode, hid_read() will wait (block) until
+			there is data to read before returning.
+
+			Nonblocking can be turned on and off at any time.
+
+			@ingroup API
+			@param device A device handle returned from hid_open().
+			@param nonblock enable or not the nonblocking reads
+			 - 1 to enable nonblocking
+			 - 0 to disable nonblocking.
+
+			@returns
+				This function returns 0 on success and -1 on error.
+		*/
+		int  HID_API_EXPORT HID_API_CALL hid_set_nonblocking(hid_device *device, int nonblock);
+
+		/** @brief Send a Feature report to the device.
+
+			Feature reports are sent over the Control endpoint as a
+			Set_Report transfer.  The first byte of @p data[] must
+			contain the Report ID. For devices which only support a
+			single report, this must be set to 0x0. The remaining bytes
+			contain the report data. Since the Report ID is mandatory,
+			calls to hid_send_feature_report() will always contain one
+			more byte than the report contains. For example, if a hid
+			report is 16 bytes long, 17 bytes must be passed to
+			hid_send_feature_report(): the Report ID (or 0x0, for
+			devices which do not use numbered reports), followed by the
+			report data (16 bytes). In this example, the length passed
+			in would be 17.
+
+			@ingroup API
+			@param device A device handle returned from hid_open().
+			@param data The data to send, including the report number as
+				the first byte.
+			@param length The length in bytes of the data to send, including
+				the report number.
+
+			@returns
+				This function returns the actual number of bytes written and
+				-1 on error.
+		*/
+		int HID_API_EXPORT HID_API_CALL hid_send_feature_report(hid_device *device, const unsigned char *data, size_t length);
+
+		/** @brief Get a feature report from a HID device.
+
+			Make sure to set the first byte of @p data[] to the Report
+			ID of the report to be read.  Make sure to allow space for
+			this extra byte in @p data[].
+
+			@ingroup API
+			@param device A device handle returned from hid_open().
+			@param data A buffer to put the read data into, including
+				the Report ID. Set the first byte of @p data[] to the
+				Report ID of the report to be read.
+			@param length The number of bytes to read, including an
+				extra byte for the report ID. The buffer can be longer
+				than the actual report.
+
+			@returns
+				This function returns the number of bytes read and
+				-1 on error.
+		*/
+		int HID_API_EXPORT HID_API_CALL hid_get_feature_report(hid_device *device, unsigned char *data, size_t length);
+
+		/** @brief Close a HID device.
+
+			@ingroup API
+			@param device A device handle returned from hid_open().
+		*/
+		void HID_API_EXPORT HID_API_CALL hid_close(hid_device *device);
+
+		/** @brief Get The Manufacturer String from a HID device.
+
+			@ingroup API
+			@param device A device handle returned from hid_open().
+			@param string A wide string buffer to put the data into.
+			@param maxlen The length of the buffer in multiples of wchar_t.
+
+			@returns
+				This function returns 0 on success and -1 on error.
+		*/
+		int HID_API_EXPORT_CALL hid_get_manufacturer_string(hid_device *device, wchar_t *string, size_t maxlen);
+
+		/** @brief Get The Product String from a HID device.
+
+			@ingroup API
+			@param device A device handle returned from hid_open().
+			@param string A wide string buffer to put the data into.
+			@param maxlen The length of the buffer in multiples of wchar_t.
+
+			@returns
+				This function returns 0 on success and -1 on error.
+		*/
+		int HID_API_EXPORT_CALL hid_get_product_string(hid_device *device, wchar_t *string, size_t maxlen);
+
+		/** @brief Get The Serial Number String from a HID device.
+
+			@ingroup API
+			@param device A device handle returned from hid_open().
+			@param string A wide string buffer to put the data into.
+			@param maxlen The length of the buffer in multiples of wchar_t.
+
+			@returns
+				This function returns 0 on success and -1 on error.
+		*/
+		int HID_API_EXPORT_CALL hid_get_serial_number_string(hid_device *device, wchar_t *string, size_t maxlen);
+
+		/** @brief Get a string from a HID device, based on its string index.
+
+			@ingroup API
+			@param device A device handle returned from hid_open().
+			@param string_index The index of the string to get.
+			@param string A wide string buffer to put the data into.
+			@param maxlen The length of the buffer in multiples of wchar_t.
+
+			@returns
+				This function returns 0 on success and -1 on error.
+		*/
+		int HID_API_EXPORT_CALL hid_get_indexed_string(hid_device *device, int string_index, wchar_t *string, size_t maxlen);
+
+		/** @brief Get a string describing the last error which occurred.
+
+			@ingroup API
+			@param device A device handle returned from hid_open().
+
+			@returns
+				This function returns a string containing the last error
+				which occurred or NULL if none has occurred.
+		*/
+		HID_API_EXPORT const wchar_t* HID_API_CALL hid_error(hid_device *device);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif
+


### PR DESCRIPTION
Hi Geert!

I ended up with including HIDAPI sources directly in my copy of go.hid. This allows Go to leverage conditional compilation because of the various suffixes of source files. This means that "go build" will work without any problems on every platform (Windows, Linux, Mac) out of the box, without the need for any manual steps (which are different for each platform).

I thought you might be interested in this change so I created a pull request for you.
