### PR TITLE
fix conversion issues for linux arm

### DIFF
--- a/hid.go
+++ b/hid.go
@@ -268,7 +268,7 @@ func Open(vendorId uint16, productId uint16, serialNumber string) (*Device, erro
 		if err != nil {
 			return nil, errors.New("Unable to convert serialNumber to WcharString")
 		}
-		serialNumberWcharPtr = (*C.wchar_t)(serialNumberWchar.Pointer())
+		serialNumberWcharPtr = (*C.wchar_t)(unsafe.Pointer(serialNumberWchar.Pointer()))
 	}
 
 	// call hid_open()
@@ -594,7 +594,7 @@ func (dev *Device) ManufacturerString() (string, error) {
 	ws := wchar.NewWcharString(100)
 
 	// retrieve manufacturer string from hid
-	res := C.hid_get_manufacturer_string(dev.hidHandle, (*C.wchar_t)(ws.Pointer()), 100)
+	res := C.hid_get_manufacturer_string(dev.hidHandle, (*C.wchar_t)(unsafe.Pointer(ws.Pointer())), 100)
 	if res != 0 {
 		return "", dev.lastError()
 	}
@@ -621,7 +621,7 @@ func (dev *Device) ProductString() (string, error) {
 	ws := wchar.NewWcharString(100)
 
 	// retrieve manufacturer string from hid
-	res := C.hid_get_product_string(dev.hidHandle, (*C.wchar_t)(ws.Pointer()), 100)
+	res := C.hid_get_product_string(dev.hidHandle, (*C.wchar_t)(unsafe.Pointer(ws.Pointer())), 100)
 	if res != 0 {
 		return "", dev.lastError()
 	}
@@ -648,7 +648,7 @@ func (dev *Device) SerialNumberString() (string, error) {
 	ws := wchar.NewWcharString(100)
 
 	// retrieve manufacturer string from hid
-	res := C.hid_get_serial_number_string(dev.hidHandle, (*C.wchar_t)(ws.Pointer()), 100)
+	res := C.hid_get_serial_number_string(dev.hidHandle, (*C.wchar_t)(unsafe.Pointer(ws.Pointer())), 100)
 	if res != 0 {
 		return "", dev.lastError()
 	}
@@ -676,7 +676,7 @@ func (dev *Device) GetIndexedString(index int) (string, error) {
 	ws := wchar.NewWcharString(256)
 
 	// retrieve manufacturer string from hid
-	res := C.hid_get_indexed_string(dev.hidHandle, C.int(index), (*C.wchar_t)(ws.Pointer()), 256)
+	res := C.hid_get_indexed_string(dev.hidHandle, C.int(index), (*C.wchar_t)(unsafe.Pointer(ws.Pointer())), 256)
 	if res != 0 {
 		return "", dev.lastError()
 	}


### PR DESCRIPTION
Fixes #11 - uses unsafe.Pointer for conversion. 